### PR TITLE
Fix: Convert StringRef to const char* in wake word engine checks for HA 2026.1

### DIFF
--- a/common/atoms3r-with-echo-base.yaml
+++ b/common/atoms3r-with-echo-base.yaml
@@ -225,7 +225,7 @@ media_player:
             - if:
                 condition:
                   - lambda: |-
-                      const char *option = id(wake_word_engine_location).current_option();
+                      const char *option = id(wake_word_engine_location).current_option().c_str();
                       return (option && std::string_view{option} == "In Home Assistant");
                 then:
                   - wait_until:
@@ -457,7 +457,7 @@ voice_assistant:
     - if:
         condition:
           - lambda: |-
-              const char *option = id(wake_word_engine_location).current_option();
+              const char *option = id(wake_word_engine_location).current_option().c_str();
               return (option && std::string_view{option} == "On device");
         then:
           - lambda: id(va).set_use_wake_word(false);
@@ -608,7 +608,7 @@ script:
               - not:
                   - voice_assistant.is_running:
               - lambda: |-
-                  const char *option = id(wake_word_engine_location).current_option();
+                  const char *option = id(wake_word_engine_location).current_option().c_str();
                   return (option && std::string_view{option} == "On device");
           then:
             - lambda: id(va).set_use_wake_word(false);
@@ -619,7 +619,7 @@ script:
               - not:
                   - voice_assistant.is_running:
               - lambda: |-
-                  const char *option = id(wake_word_engine_location).current_option();
+                  const char *option = id(wake_word_engine_location).current_option().c_str();
                   return (option && std::string_view{option} == "In Home Assistant");
           then:
             - lambda: id(va).set_use_wake_word(true);
@@ -630,7 +630,7 @@ script:
       - if:
           condition:
             lambda: |-
-              const char *option = id(wake_word_engine_location).current_option();
+              const char *option = id(wake_word_engine_location).current_option().c_str();
               return (option && std::string_view{option} == "In Home Assistant");
           then:
             - lambda: id(va).set_use_wake_word(false);
@@ -638,7 +638,7 @@ script:
       - if:
           condition:
             lambda: |-
-              const char *option = id(wake_word_engine_location).current_option();
+              const char *option = id(wake_word_engine_location).current_option().c_str();
               return (option && std::string_view{option} == "On device");
           then:
             - micro_wake_word.stop:


### PR DESCRIPTION
# Fix: Convert StringRef to const char* in wake word engine checks

## Description
This PR fixes a type conversion issue in the `atoms3r-with-echo-base.yaml` configuration file where `current_option()` returns a `StringRef` object that needs to be converted to `const char*` using `.c_str()` before comparison with string literals.

## Problem
The lambda functions were attempting to directly assign the result of `current_option()` to a `const char*` pointer without proper conversion, which could cause compilation issues or runtime errors depending on the ESPHome version.

## Solution
Added `.c_str()` method calls to all wake word engine location checks to properly convert the `StringRef` return value to a C-style string pointer.

## Changes
- Updated 6 lambda functions in `common/atoms3r-with-echo-base.yaml` to use `.c_str()` for proper type conversion
- Ensures compatibility with the select API changes introduced in ESPHome 2025.12.0

## Files Changed
- `common/atoms3r-with-echo-base.yaml`
