### PR TITLE
Update option retrieval to use c_str() method

### DIFF
--- a/common/atom-echos3r-satellite-base.yaml
+++ b/common/atom-echos3r-satellite-base.yaml
@@ -170,7 +170,7 @@ media_player:
             - if:
                 condition:
                   - lambda: |-
-                      const char *option = id(wake_word_engine_location).current_option();
+                      const char *option = id(wake_word_engine_location).current_option().c_str();
                       return (option && std::string_view{option} == "In Home Assistant");
                 then:
                   - wait_until:
@@ -261,7 +261,7 @@ voice_assistant:
     - if:
         condition:
           - lambda: |-
-              const char *option = id(wake_word_engine_location).current_option();
+              const char *option = id(wake_word_engine_location).current_option().c_str();
               return (option && std::string_view{option} == "On device");
         then:
           - lambda: id(va).set_use_wake_word(false);
@@ -324,7 +324,7 @@ script:
               - not:
                   - voice_assistant.is_running:
               - lambda: |-
-                  const char *option = id(wake_word_engine_location).current_option();
+                  const char *option = id(wake_word_engine_location).current_option().c_str();
                   return (option && std::string_view{option} == "On device");
           then:
             - lambda: id(va).set_use_wake_word(false);
@@ -335,7 +335,7 @@ script:
               - not:
                   - voice_assistant.is_running:
               - lambda: |-
-                  const char *option = id(wake_word_engine_location).current_option();
+                  const char *option = id(wake_word_engine_location).current_option().c_str();
                   return (option && std::string_view{option} == "In Home Assistant");
           then:
             - lambda: id(va).set_use_wake_word(true);
@@ -346,7 +346,7 @@ script:
       - if:
           condition:
             lambda: |-
-              const char *option = id(wake_word_engine_location).current_option();
+              const char *option = id(wake_word_engine_location).current_option().c_str();
               return (option && std::string_view{option} == "In Home Assistant");
           then:
             - lambda: id(va).set_use_wake_word(false);
@@ -354,7 +354,7 @@ script:
       - if:
           condition:
             lambda: |-
-              const char *option = id(wake_word_engine_location).current_option();
+              const char *option = id(wake_word_engine_location).current_option().c_str();
               return (option && std::string_view{option} == "On device");
           then:
             - micro_wake_word.stop:


### PR DESCRIPTION
Fixed compilation errors caused by esphome::StringRef type mismatch. Updated current_option() calls in atom-echos3r-satellite-base.yaml to use .c_str() to ensure compatibility with const char* assignments as required by recent ESPHome core updates.