### PR TITLE
Add id for Wake word Sensitivity

### DIFF
--- a/common/atom-echos3r-satellite-base.yaml
+++ b/common/atom-echos3r-satellite-base.yaml
@@ -488,6 +488,7 @@ select:
 
   - platform: template
     name: "Wake word sensitivity"
+    id: wake_word_sensitivity
     optimistic: true
     initial_option: Slightly sensitive
     restore_value: true


### PR DESCRIPTION
I have a custom configuration with the following yaml to add a custom wake word:

```
packages:
  remote_package_files:
    url: https://github.com/m5stack/esphome-yaml
    files: [ common/atom-echos3r-satellite-base.yaml ]
    ref: main
    refresh: 0s

micro_wake_word:
  id: mww
  models:
    - model: github://TaterTotterson/microWakeWords/microWakeWords/computer.json
      id: computer
```

I also want to modify the "wake word sensitivity" for this new model. This should be possible with the following but only if the select has an ID:

```
select:
  - id: !extend wake_word_sensitivity
    on_value:
      # Sets specific wake word probabilities computed for each particular model
      # Note probability cutoffs are set as a quantized uint8 value, each comment has the corresponding floating point cutoff
      # False Accepts per Hour values are tested against all units and channels from the Dinner Party Corpus.
      # These cutoffs apply only to the specific models included in the firmware: okay_nabu@20241226.3, hey_jarvis@v2, hey_mycroft@v2
      lambda: |-
        if (x == "Slightly sensitive") {
         id(okay_nabu).set_probability_cutoff(217);    // 0.85 -> 0.000 FAPH on DipCo (Manifest's default)
          id(hey_jarvis).set_probability_cutoff(247);   // 0.97 -> 0.563 FAPH on DipCo (Manifest's default)
          id(hey_mycroft).set_probability_cutoff(253);  // 0.99 -> 0.567 FAPH on DipCo
          id(computer).set_probability_cutoff(253);     // 0.99 -> 0.567 FAPH on DipCo
        } else if (x == "Moderately sensitive") {
          id(okay_nabu).set_probability_cutoff(176);    // 0.69 -> 0.376 FAPH on DipCo
          id(hey_jarvis).set_probability_cutoff(235);   // 0.92 -> 0.939 FAPH on DipCo
          id(hey_mycroft).set_probability_cutoff(242);  // 0.95 -> 1.502 FAPH on DipCo (Manifest's default)
          id(computer).set_probability_cutoff(247);     // 0.97 -> 0.563 FAPH on DipCo (Manifest's default)
        } else if (x == "Very sensitive") {
          id(okay_nabu).set_probability_cutoff(143);    // 0.56 -> 0.751 FAPH on DipCo
          id(hey_jarvis).set_probability_cutoff(212);   // 0.83 -> 1.502 FAPH on DipCo
          id(hey_mycroft).set_probability_cutoff(237);  // 0.93 -> 1.878 FAPH on DipCo
          id(computer).set_probability_cutoff(237);     // 0.93 -> 1.878 FAPH on DipCo
        }
```