### PR TITLE
Add more factory firmware YAML and partially refactor the powerhub component

### DIFF
--- a/common/unit-poe-cam-w-v1-rev1-base.yaml
+++ b/common/unit-poe-cam-w-v1-rev1-base.yaml
@@ -1,6 +1,7 @@
 esphome:
   name: unit-poe-cam-w-v1-rev1
   friendly_name: M5Stack Unit POE CAM V1.1
+  name_add_mac_suffix: true
 
 esp32:
   variant: esp32
@@ -46,7 +47,9 @@ ethernet:
 i2c:
   - id: cam_i2c
     sda: GPIO14
-    scl: GPIO12
+    scl: 
+      number: GPIO12
+      ignore_strapping_warning: true
 
 
 esp32_camera:
@@ -59,8 +62,9 @@ esp32_camera:
   vsync_pin: GPIO22 
   href_pin: GPIO26
   pixel_clock_pin: GPIO21
-  reset_pin: GPIO15
-
+  reset_pin:
+    number: GPIO15
+    ignore_strapping_warning: true
 
 binary_sensor:
   - platform: gpio
@@ -74,6 +78,7 @@ output:
     pin:
       number: GPIO0
       inverted: true
+      ignore_strapping_warning: true
     id: status_led
 
 light:

--- a/components/powerhub/README.md
+++ b/components/powerhub/README.md
@@ -130,7 +130,7 @@ sensor:
 
 ## Text Sensor
 
-Text sensors on `powerhub` report the power status in text format, as well as the internal firmware/bootloader version of the device.
+Text sensors on `powerhub` report the power status in text format.
 
 ```yaml
 text_sensor:
@@ -141,12 +141,6 @@ text_sensor:
     vin_status:
       name: "External Input Power Status"
       id: ext_vin_status_text_sensor
-    firmware_ver:
-      name: "Internal Firmware Version"
-      id: int_firm_ver_text_sensor
-    bootloader_ver:
-      name: "Bootloader Version"
-      id: boot_ver_text_sensor
 ```
 
 ### Configuration variables
@@ -155,11 +149,11 @@ text_sensor:
   All options from [Text Sensor](/components/text_sensor#config-text_sensor).
 - **vin_status** (*Optional*): Detect if external input power is present.
   All options from [Text Sensor](/components/text_sensor#config-text_sensor).
-- **firmware_ver** (*Optional*): Report the internal firmware version of the device.
-  All options from [Text Sensor](/components/text_sensor#config-text_sensor).
-- **bootloader_ver** (*Optional*): Bootloader version of the device.
-  All options from [Text Sensor](/components/text_sensor#config-text_sensor).
 - **powerhub_id** (*Optional*, [ID](/guides/configuration-types#id)): The ID to PowerHub.
+
+> [!NOTE]
+> The `charge_status` and `vin_status` text sensors implement a caching mechanism to avoid republishing unchanged values. 
+> States are only published when the actual status changes, reducing MQTT message traffic and Home Assistant event processing.
 
 ## Switch
 
@@ -168,50 +162,56 @@ The `powerhub` switches allow you to enable or disable power channels from the f
 ```yaml
 switch:
   - platform: powerhub
-    led_pwr:
-      name: "LED Power"
-      id: led_pwr_switch
-    usb_pwr:
-      name: "USB Power"
-      id: usb_pwr_switch
-    grove_red_pwr:
-      name: "Port.A Power"
-      id: grove_red_pwr_switch
-    grove_blue_pwr:
-      name: "Port.C Power"
-      id: grove_blue_pwr_switch
-    rs485_can_pwr:
-      name: "RS485&CAN Power"
-      id: rs485_can_pwr_switch
-    vameter_pwr:
-      name: "VAMeter Power"
-      id: vameter_pwr_switch
-    charge_pwr:
-      name: "Charge Power"
-      id: charge_pwr_switch
-    rs485_can_direction:
-      name: "RS485&CAN Power Output"
-      id: rs485_can_direction_switch
+    channel: LED
+    name: "LED Power"
+    id: led_pwr_switch
+  
+  - platform: powerhub
+    channel: USB
+    name: "USB Power"
+    id: usb_pwr_switch
+  
+  - platform: powerhub
+    channel: GROVE_RED
+    name: "Port.A Power"
+    id: grove_red_pwr_switch
+  
+  - platform: powerhub
+    channel: GROVE_BLUE
+    name: "Port.C Power"
+    id: grove_blue_pwr_switch
+  
+  - platform: powerhub
+    channel: RS485_CAN
+    name: "RS485&CAN Power"
+    id: rs485_can_pwr_switch
+  
+  - platform: powerhub
+    channel: VAMETER
+    name: "VAMeter Power"
+    id: vameter_pwr_switch
+  
+  - platform: powerhub
+    channel: CHARGE
+    name: "Charge Power"
+    id: charge_pwr_switch
+  
+  - platform: powerhub
+    name: "RS485 CAN Direction"
+    id: rs485_can_dir_switch
 ```
 
 ### Configuration variables
 
-- **led_pwr** (*Optional*): Turn on/off the LED power. Defaults to `true`.
-  All options from [Switch](/components/switch#config-switch)
-- **usb_pwr** (*Optional*): Turn on/off the USB power.
-  All options from [Switch](/components/switch#config-switch)
-- **grove_red_pwr** (*Optional*): Turn on/off the Port.A (grove red) power.
-  All options from [Switch](/components/switch#config-switch)
-- **grove_blue_pwr** (*Optional*): Turn on/off the Port.C (grove blue) power.
-  All options from [Switch](/components/switch#config-switch)
-- **rs485_can_pwr** (*Optional*): Turn on/off the RS485 & CAN power.
-  All options from [Switch](/components/switch#config-switch)
-- **vameter_pwr** (*Optional*): Turn on/off the VAMeter power. Defaults to `true`
-  All options from [Switch](/components/switch#config-switch)
-- **charge_pwr** (*Optional*): Turn on/off the charge power. Defaults to `true`
-  All options from [Switch](/components/switch#config-switch)
-- **rs485_can_direction** (*Optional*): Control the RS485 & CAN power output direction. Turn on to enable the output.
-  All options from [Switch](/components/switch#config-switch)
+- **channel** (*Required* for power channel switches): The power channel to control. 
+  Valid values: `LED`, `USB`, `GROVE_RED`, `GROVE_BLUE`, `RS485_CAN`, `VAMETER`, `CHARGE`.
+  All options from [Switch](/components/switch#config-switch).
+- **name** (*Optional*): The name of the switch.
+  All options from [Switch](/components/switch#config-switch).
+- **id** (*Optional*, [ID](/guides/configuration-types#id)): An identifier for the switch.
+- **rs485_can_direction**: A special switch (without `channel`) that controls the RS485 & CAN power direction. 
+  Turn on to enable power output for RS485/CAN interface.
+  All other options from [Switch](/components/switch#config-switch).
 - **powerhub_id** (*Optional*, [ID](/guides/configuration-types#id)): The ID to PowerHub.
 
 ## Select
@@ -248,13 +248,19 @@ number:
 
 ### Configuration variables
 
-- **rs485_can_output_voltage** (*Optional*): Set the output voltage of the RS485 & CAN interface. Defaults to `3000` mV.
+- **rs485_can_output_voltage** (*Optional*): Set the output voltage of the RS485 & CAN interface. 
+  Defaults to `3000` mV. The valid range is 3000 mV to 20000 mV with a step of 20 mV.
   The switch `rs485_can_direction` needs to be enabled for this to take effect.
   All options from [Number](/components/number#config-number).
-- **rs485_can_current_limit** (*Optional*): Set the output current limit of the RS485 & CAN interface. Defaults to `13` mA. 
+- **rs485_can_current_limit** (*Optional*): Set the output current limit of the RS485 & CAN interface. 
+  Defaults to `13` mA. The valid range is 13 mA to 3000 mA.
   The switch `rs485_can_direction` needs to be enabled for this to take effect.
   All options from [Number](/components/number#config-number).
 - **powerhub_id** (*Optional*, [ID](/guides/configuration-types#id)): The ID to PowerHub.
+
+> [!NOTE]
+> The default voltage (3000 mV / 3.0V) and current limit (13 mA) are set during initialization when the device boots. 
+> These values are synchronized with the internal state, ensuring consistency between the hardware configuration and the Home Assistant frontend.
 
 ## Light
 
@@ -263,43 +269,59 @@ Each power channel on `powerhub` is equipped with a status RGB LED to indicate t
 ```yaml
 light:
   - platform: powerhub
-    usb_c_rgb:
-      name: "USB C Light"
-    usb_a_rgb:
-      name: "USB A Light"
-    grove_blue_rgb:
-      name: "Port.C Light"
-    grove_red_rgb:
-      name: "Port.A Light"
-    rs485_can_rgb:
-      name: "RS485&CAN Light"
-    bat_charge_rgb:
-      name: "Battery Charge Light"
-    pwr_l_rgb:
-      name: "Power L Light"
-    pwr_r_rgb:
-      name: "Power R Light"
+    channel: USB_A
+    name: "USB A Light"
+    id: led_usb_a
+
+  - platform: powerhub
+    channel: USB_C
+    name: "USB C Light"
+    id: led_usb_c
+
+  - platform: powerhub
+    channel: GROVE_BLUE
+    name: "Port.C Light"
+    id: led_grove_blue
+
+  - platform: powerhub
+    channel: GROVE_RED
+    name: "Port.A Light"
+    id: led_grove_red
+
+  - platform: powerhub
+    channel: RS485_CAN
+    name: "RS485&CAN Light"
+    id: led_rs485_can
+
+  - platform: powerhub
+    channel: CHARGE
+    name: "Battery Charge Light"
+    id: led_bat_charge
+    effects:
+      - pulse:
+          name: "Slow Pulse"
+          transition_length: 500ms
+          update_interval: 2s
+
+  - platform: powerhub
+    channel: POWER_LEFT
+    name: "Power L Light"
+    id: led_pwr_l
+
+  - platform: powerhub
+    channel: POWER_RIGHT
+    name: "Power R Light"
+    id: led_pwr_r
 ```
 
 ### Configuration variables
 
-- **usb_c_rgb** (*Optional*): Turn on/off RGB LED under the USB Type C interface.
-  All other options from [Light](/components/light#config-light).
-- **usb_a_rgb** (*Optional*): Turn on/off RGB LED under the USB Type A interface.
-  All other options from [Light](/components/light#config-light).
-- **grove_blue_rgb** (*Optional*): Turn on/off RGB LED under the Port.C (grove blue) interface.
-  All other options from [Light](/components/light#config-light).
-- **grove_red_rgb** (*Optional*): Turn on/off RGB LED under the Port.A (grove red) interface.
-  All other options from [Light](/components/light#config-light).
-- **rs485_can_rgb** (*Optional*): Turn on/off RGB LED under the RS485 & CAN interface.
-  All other options from [Light](/components/light#config-light).
-- **bat_charge_rgb** (*Optional*): Turn on/off RGB LED for battery charge status. This LED is located under the yellow round button.
-  All other options from [Light](/components/light#config-light).
-- **pwr_l_rgb** (*Optional*): Turn on/off RGB LED for left power indicator. This LED is located inside the left half of the Top PMU button (rectangular shape).
-  All other options from [Light](/components/light#config-light).
-- **pwr_r_rgb** (*Optional*): Turn on/off RGB LED for right power indicator. This LED is located inside the right half of the Top PMU button (rectangular shape).
-  All other options from [Light](/components/light#config-light).
+- **channel** (*Required*): The RGB LED channel to control.
+  Valid values: `USB_A`, `USB_C`, `GROVE_RED`, `GROVE_BLUE`, `RS485_CAN`, `CHARGE`, `POWER_LEFT`, `POWER_RIGHT`.
+- **name** (*Optional*): The name of the light.
+- **id** (*Optional*, [ID](/guides/configuration-types#id)): An identifier for the light.
 - **powerhub_id** (*Optional*, [ID](/guides/configuration-types#id)): The ID to PowerHub.
+- All other options from [Light](/components/light#config-light).
 
 
 The RGB LED is designed to conveniently indicate the power status of each channel, with the readings of Sensors, you can update your Light component accordingly. 
@@ -393,71 +415,21 @@ or turn on/off the corresponding LEDs when turn on/off the power switches.
 ```yaml
 switch:
   - platform: powerhub
-    ...
-    usb_pwr:
-      name: "USB Power"
-      id: usb_pwr_switch
-      on_turn_on:
-        - light.turn_on:
-            id: led_usb_a
-            brightness: 90%
-            # Color maybe
-            # red: 100%
-            # green: 100%
-            # blue: 100%
-        - light.turn_on:
-            id: led_usb_c
-            brightness: 90%
-      on_turn_off:
-        - light.turn_off:
-            id: led_usb_a
-        - light.turn_off:
-            id: led_usb_c
-
-    grove_red_pwr:
-      name: "Port.A Power"
-      id: grove_red_pwr_switch
-      on_turn_on:
-        - light.turn_on:
-            id: led_grove_red
-            brightness: 90%
-      on_turn_off:
-        - light.turn_off:
-            id: led_grove_red
-
-    grove_blue_pwr:
-      name: "Port.C Power"
-      id: grove_blue_pwr_switch
-      on_turn_on:
-        - light.turn_on:
-            id: led_grove_blue
-            brightness: 90%
-      on_turn_off:
-        - light.turn_off:
-            id: led_grove_blue
-
-    rs485_can_pwr:
-      name: "RS485&CAN Power"
-      id: rs485_can_pwr_switch
-      on_turn_on:
-        - light.turn_on:
-            id: led_rs485_can
-            brightness: 90%
-      on_turn_off:
-        - light.turn_off:
-            id: led_rs485_can
-
-    charge_pwr:
-      name: "Charge Power"
-      id: charge_pwr_switch
-      restore_mode: RESTORE_DEFAULT_ON
-      on_turn_on:
-        - light.turn_on:
-            id: led_bat_charge
-            brightness: 90%
-      on_turn_off:
-        - light.turn_off:
-            id: led_bat_charge
+    channel: USB
+    name: "USB Power"
+    id: usb_pwr_switch
+    on_turn_on:
+      - light.turn_on:
+          id: led_usb_a
+          brightness: 90%
+      - light.turn_on:
+          id: led_usb_c
+          brightness: 90%
+    on_turn_off:
+      - light.turn_off:
+          id: led_usb_a
+      - light.turn_off:
+          id: led_usb_c
     ...
 ```
 
@@ -466,15 +438,14 @@ You can also add some special effects to the light, for an example, when battery
 ```yaml
 light:
   - platform: powerhub
-    ...
-    bat_charge_rgb:
-      id: led_bat_charge
-      name: "Battery Charge Light"
-      effects:
-        - pulse:
-            name: "Slow Pulse"
-            transition_length: 500ms
-            update_interval: 2s
+    channel: CHARGE
+    name: "Battery Charge Light"
+    id: led_bat_charge
+    effects:
+      - pulse:
+          name: "Slow Pulse"
+          transition_length: 500ms
+          update_interval: 2s
     ...
 ```
 

--- a/components/powerhub/light/__init__.py
+++ b/components/powerhub/light/__init__.py
@@ -1,10 +1,10 @@
 import esphome.codegen as cg
 import esphome.config_validation as cv
-from esphome.components import light, output
+from esphome.components import light
 
 from esphome.const import (
-    CONF_ID,
-    ENTITY_CATEGORY_CONFIG,
+    CONF_OUTPUT_ID,
+    CONF_CHANNEL,
 )
 
 CODEOWNERS = ["@m5stack"]
@@ -12,103 +12,32 @@ DEPENDENCIES = ["powerhub"]
 
 from .. import powerhub_ns, BASE_SCHEMA, CONF_POWER_HUB_ID
 
-USBCLight = powerhub_ns.class_("USBCLight", light.LightOutput)
-USBALight = powerhub_ns.class_("USBALight", light.LightOutput)
-GroveBlueLight = powerhub_ns.class_("GroveBlueLight", light.LightOutput)
-GroveRedLight = powerhub_ns.class_("GroveRedLight", light.LightOutput)
-RS485CANLight = powerhub_ns.class_("RS485CANLight", light.LightOutput)
-BATChargeLight = powerhub_ns.class_("BATChargeLight", light.LightOutput)
-PowerLeftLight = powerhub_ns.class_("PowerLeftLight", light.LightOutput)
-PowerRightLight = powerhub_ns.class_("PowerRightLight", light.LightOutput)
+PowerHubLight = powerhub_ns.class_("PowerHubLight", light.LightOutput)
+LightChannel = powerhub_ns.enum("LightChannel", is_class=True)
 
-CONF_USB_C_RGB = "usb_c_rgb"
-CONF_USB_A_RGB = "usb_a_rgb"
-CONF_GROVE_BLUE_RGB = "grove_blue_rgb"
-CONF_GROVE_RED_RGB = "grove_red_rgb"
-CONF_RS485_CAN_RGB = "rs485_can_rgb"
-CONF_BAT_CHARGE_RGB = "bat_charge_rgb"
-CONF_PWR_L_RGB = "pwr_l_rgb"
-CONF_PWR_R_RGB = "pwr_r_rgb"
+LIGHT_CHANNEL = {
+    "USB_A":       LightChannel.LED_USB_A,
+    "USB_C":       LightChannel.LED_USB_C,
+    "GROVE_RED":   LightChannel.LED_GROVE_RED,
+    "GROVE_BLUE":  LightChannel.LED_GROVE_BLUE,
+    "RS485_CAN":   LightChannel.LED_RS485_CAN,
+    "CHARGE":      LightChannel.LED_CHARGE,
+    "POWER_LEFT":  LightChannel.LED_POWER_LEFT,
+    "POWER_RIGHT": LightChannel.LED_POWER_RIGHT,
+}
 
-
-CONFIG_SCHEMA = cv.Schema(
+CONFIG_SCHEMA = light.light_schema(
+    PowerHubLight,
+    light.LightType.RGB,
+).extend(
     {
-        cv.Optional(CONF_USB_C_RGB): light.light_schema(
-            USBCLight,
-            light.LightType.RGB,
-        ),
-        cv.Optional(CONF_USB_A_RGB): light.light_schema(
-            USBALight,
-            light.LightType.RGB
-        ),
-        cv.Optional(CONF_GROVE_BLUE_RGB): light.light_schema(
-            GroveBlueLight,
-            light.LightType.RGB
-        ),
-        cv.Optional(CONF_GROVE_RED_RGB): light.light_schema(
-            GroveRedLight,
-            light.LightType.RGB
-        ),
-        cv.Optional(CONF_RS485_CAN_RGB): light.light_schema(
-            RS485CANLight,
-            light.LightType.RGB
-        ),
-        cv.Optional(CONF_BAT_CHARGE_RGB): light.light_schema(
-            BATChargeLight,
-            light.LightType.RGB
-        ),
-        cv.Optional(CONF_PWR_L_RGB): light.light_schema(
-            PowerLeftLight,
-            light.LightType.RGB
-        ),
-        cv.Optional(CONF_PWR_R_RGB): light.light_schema(
-            PowerRightLight,
-            light.LightType.RGB
-        ),
+        cv.Required(CONF_CHANNEL): cv.enum(LIGHT_CHANNEL),
     }
 ).extend(BASE_SCHEMA)
 
 
 async def to_code(config):
-
-    if CONF_USB_C_RGB in config:
-        var = await light.new_light(config[CONF_USB_C_RGB])
-        await cg.register_parented(var, config[CONF_POWER_HUB_ID])
-
-    if CONF_USB_A_RGB in config:
-        var = await light.new_light(config[CONF_USB_A_RGB])
-        await cg.register_parented(var, config[CONF_POWER_HUB_ID])
-
-    if CONF_GROVE_BLUE_RGB in config:
-        var = await light.new_light(config[CONF_GROVE_BLUE_RGB])
-        await cg.register_parented(var, config[CONF_POWER_HUB_ID])
-
-    if CONF_GROVE_RED_RGB in config:
-        var = await light.new_light(config[CONF_GROVE_RED_RGB])
-        await cg.register_parented(var, config[CONF_POWER_HUB_ID])
-
-    if CONF_RS485_CAN_RGB in config:
-        var = await light.new_light(config[CONF_RS485_CAN_RGB])
-        await cg.register_parented(var, config[CONF_POWER_HUB_ID])
-
-    if CONF_BAT_CHARGE_RGB in config:
-        var = await light.new_light(config[CONF_BAT_CHARGE_RGB])
-        await cg.register_parented(var, config[CONF_POWER_HUB_ID])
-
-    if CONF_PWR_L_RGB in config:
-        var = await light.new_light(config[CONF_PWR_L_RGB])
-        await cg.register_parented(var, config[CONF_POWER_HUB_ID])
-
-    if CONF_PWR_R_RGB in config:
-        var = await light.new_light(config[CONF_PWR_R_RGB])
-        await cg.register_parented(var, config[CONF_POWER_HUB_ID])
-
-
-
-
-
-
-
-
-
-
+    var = cg.new_Pvariable(config[CONF_OUTPUT_ID])
+    await light.register_light(var, config)
+    await cg.register_parented(var, config[CONF_POWER_HUB_ID])
+    cg.add(var.set_channel(config[CONF_CHANNEL]))

--- a/components/powerhub/light/powerhub_light.cpp
+++ b/components/powerhub/light/powerhub_light.cpp
@@ -1,4 +1,5 @@
 #include "powerhub_light.h"
+#include "esphome/core/progmem.h"
 
 
 namespace esphome {
@@ -17,184 +18,81 @@ static uint8_t to_uint8_t(float value, int scale_factor) {
     return static_cast<uint8_t>(value * scale_factor);
 }
 
-light::LightTraits USBCLight::get_traits() {
+#if ESPHOME_LOG_LEVEL >= ESPHOME_LOG_LEVEL_DEBUG
+PROGMEM_STRING_TABLE(LightChannelStrings,
+  "USB Type A Light",
+  "USB Type C Light",
+  "Grove Red Light",
+  "Grove Blue Light",
+  "RS485 CAN Light",
+  "Charge Light",
+  "Power Left Light",
+  "Power Right Light",
+  "Unknown"
+);
+
+static const LogString *power_channel_to_str(LightChannel channel) {
+  return LightChannelStrings::get_log_str(static_cast<uint8_t>(channel), -1);
+}
+
+#endif
+
+light::LightTraits PowerHubLight::get_traits() {
     auto traits = light::LightTraits();
     traits.set_supported_color_modes({light::ColorMode::RGB});
     return traits;
 }
 
-void USBCLight::write_state(light::LightState *state) {
-    float r, g, b;
-    float brightness;
-
-    state->current_values_as_rgb(&r, &g, &b);
-    state->current_values_as_brightness(&brightness);
-
-    BGR_t color {
-        .b = to_uint8_t(b, 255),
-        .g = to_uint8_t(g, 255),
-        .r = to_uint8_t(r, 255)
-    };
-
-    this->parent_->set_led_usb_c_color(color);
-    this->parent_->set_brightness_usb_c(to_uint8_t(brightness, 100));
-
-    state->publish_state();
+void PowerHubLight::write_state(light::LightState *state) {
+  float r, g, b, brightness = 0.0f;
+  state->current_values_as_rgb(&r, &g, &b);
+  state->current_values_as_brightness(&brightness);
+  BGR_t color {
+    .b = to_uint8_t(b, 255),
+    .g = to_uint8_t(g, 255),
+    .r = to_uint8_t(r, 255)
+  };
+  switch (this->channel_) {
+    case LightChannel::LED_USB_A:
+      this->parent_->set_led_usb_a_color(color);
+      this->parent_->set_brightness_usb_a(to_uint8_t(brightness, 100));
+      break;
+    case LightChannel::LED_USB_C:
+      this->parent_->set_led_usb_c_color(color);
+      this->parent_->set_brightness_usb_c(to_uint8_t(brightness, 100));
+      break;
+    case LightChannel::LED_GROVE_BLUE:
+      this->parent_->set_led_grove_blue_color(color);
+      this->parent_->set_brightness_grove_blue(to_uint8_t(brightness, 100));
+      break;
+    case LightChannel::LED_GROVE_RED:
+      this->parent_->set_led_grove_red_color(color);
+      this->parent_->set_brightness_grove_red(to_uint8_t(brightness, 100));
+      break;
+    case LightChannel::LED_RS485_CAN:
+      this->parent_->set_led_rs485_can_color(color);
+      this->parent_->set_brightness_rs485_can(to_uint8_t(brightness, 100));
+      break;
+    case LightChannel::LED_CHARGE:
+      this->parent_->set_led_bat_charge_color(color);
+      this->parent_->set_brightness_bat_charge(to_uint8_t(brightness, 100));
+      break;
+    case LightChannel::LED_POWER_LEFT:
+      this->parent_->set_led_pwr_l_color(color);
+      this->parent_->set_brightness_pwr_l(to_uint8_t(brightness, 100));
+      break;
+    case LightChannel::LED_POWER_RIGHT:
+      this->parent_->set_led_pwr_r_color(color);
+      this->parent_->set_brightness_pwr_r(to_uint8_t(brightness, 100));
+      break;
+    default:
+      ESP_LOGW(TAG, "Unknown light channel");
+      break;
+  }
+  state->publish_state();
 }
 
-light::LightTraits USBALight::get_traits() {
-    auto traits = light::LightTraits();
-    traits.set_supported_color_modes({light::ColorMode::RGB});
-    return traits;
-}
 
-void USBALight::write_state(light::LightState *state) {
-    float r, g, b, brightness;
-    state->current_values_as_rgb(&r, &g, &b);
-    state->current_values_as_brightness(&brightness);
-
-    BGR_t color {
-        .b = to_uint8_t(b, 255),
-        .g = to_uint8_t(g, 255),
-        .r = to_uint8_t(r, 255)
-    };
-
-    this->parent_->set_led_usb_a_color(color);
-    this->parent_->set_brightness_usb_a(to_uint8_t(brightness, 100));
-    state->publish_state();
-}
-
-light::LightTraits GroveBlueLight::get_traits() {
-    auto traits = light::LightTraits();
-    traits.set_supported_color_modes({light::ColorMode::RGB});
-    return traits;
-}
-
-void GroveBlueLight::write_state(light::LightState *state) {
-    float r, g, b, brightness;
-    state->current_values_as_rgb(&r, &g, &b);
-    state->current_values_as_brightness(&brightness);
-
-    BGR_t color {
-        .b = to_uint8_t(b, 255),
-        .g = to_uint8_t(g, 255),
-        .r = to_uint8_t(r, 255)
-    };
-
-    this->parent_->set_led_grove_blue_color(color);
-    this->parent_->set_brightness_grove_blue(to_uint8_t(brightness, 100));
-    state->publish_state();
-}
-
-light::LightTraits GroveRedLight::get_traits() {
-    auto traits = light::LightTraits();
-    traits.set_supported_color_modes({light::ColorMode::RGB});
-    return traits;
-}
-
-void GroveRedLight::write_state(light::LightState *state) {
-    float r, g, b, brightness;
-    state->current_values_as_rgb(&r, &g, &b);
-    state->current_values_as_brightness(&brightness);
-
-    BGR_t color {
-        .b = to_uint8_t(b, 255),
-        .g = to_uint8_t(g, 255),
-        .r = to_uint8_t(r, 255)
-    };
-
-    this->parent_->set_led_grove_red_color(color);
-    this->parent_->set_brightness_grove_red(to_uint8_t(brightness, 100));
-    state->publish_state();
-}
-
-light::LightTraits RS485CANLight::get_traits() {
-    auto traits = light::LightTraits();
-    traits.set_supported_color_modes({light::ColorMode::RGB});
-    return traits;
-}
-
-void RS485CANLight::write_state(light::LightState *state) {
-    float r, g, b, brightness;
-    state->current_values_as_rgb(&r, &g, &b);
-    state->current_values_as_brightness(&brightness);
-
-    BGR_t color {
-        .b = to_uint8_t(b, 255),
-        .g = to_uint8_t(g, 255),
-        .r = to_uint8_t(r, 255)
-    };
-
-    this->parent_->set_led_rs485_can_color(color);
-    this->parent_->set_brightness_rs485_can(to_uint8_t(brightness, 100));
-    state->publish_state();
-}
-
-light::LightTraits BATChargeLight::get_traits() {
-    auto traits = light::LightTraits();
-    traits.set_supported_color_modes({light::ColorMode::RGB});
-    return traits;
-}
-
-void BATChargeLight::write_state(light::LightState *state) {
-    float r, g, b, brightness;
-    state->current_values_as_rgb(&r, &g, &b);
-    state->current_values_as_brightness(&brightness);
-
-    BGR_t color {
-        .b = to_uint8_t(b, 255),
-        .g = to_uint8_t(g, 255),
-        .r = to_uint8_t(r, 255)
-    };
-
-    this->parent_->set_led_bat_charge_color(color);
-    this->parent_->set_brightness_bat_charge(to_uint8_t(brightness, 100));
-    state->publish_state();
-}
-
-light::LightTraits PowerLeftLight::get_traits() {
-    auto traits = light::LightTraits();
-    traits.set_supported_color_modes({light::ColorMode::RGB});
-    return traits;
-}
-
-void PowerLeftLight::write_state(light::LightState *state) {
-    float r, g, b, brightness;
-    state->current_values_as_rgb(&r, &g, &b);
-    state->current_values_as_brightness(&brightness);
-
-    BGR_t color {
-        .b = to_uint8_t(b, 255),
-        .g = to_uint8_t(g, 255),
-        .r = to_uint8_t(r, 255)
-    };
-
-    this->parent_->set_led_pwr_l_color(color);
-    this->parent_->set_brightness_pwr_l(to_uint8_t(brightness, 100));
-    state->publish_state();
-}
-
-light::LightTraits PowerRightLight::get_traits() {
-    auto traits = light::LightTraits();
-    traits.set_supported_color_modes({light::ColorMode::RGB});
-    return traits;
-}
-
-void PowerRightLight::write_state(light::LightState *state) {
-    float r, g, b, brightness;
-    state->current_values_as_rgb(&r, &g, &b);
-    state->current_values_as_brightness(&brightness);
-
-    BGR_t color {
-        .b = to_uint8_t(b, 255),
-        .g = to_uint8_t(g, 255),
-        .r = to_uint8_t(r, 255)
-    };
-
-    this->parent_->set_led_pwr_r_color(color);
-    this->parent_->set_brightness_pwr_r(to_uint8_t(brightness, 100));
-    state->publish_state();
-}
 
 } // namespace powerhub
 } // namespace esphome

--- a/components/powerhub/light/powerhub_light.h
+++ b/components/powerhub/light/powerhub_light.h
@@ -8,70 +8,30 @@
 namespace esphome {
 namespace powerhub {
 
-class USBCLight : public light::LightOutput,
-                  public Parented<PowerHub>
-{
-public:
-    light::LightTraits get_traits() override;
-    void write_state(light::LightState *state) override;
+enum class LightChannel {
+  LED_USB_A,
+  LED_USB_C,
+  LED_GROVE_RED,
+  LED_GROVE_BLUE,
+  LED_RS485_CAN,
+  LED_CHARGE,
+  LED_POWER_LEFT,
+  LED_POWER_RIGHT
 };
 
-class USBALight : public light::LightOutput,
-                  public Parented<PowerHub>
-{
-public:
-    light::LightTraits get_traits() override;
-    void write_state(light::LightState *state) override;
-};
-
-class GroveBlueLight : public light::LightOutput,
-                       public Parented<PowerHub>
-{
-public:
-    light::LightTraits get_traits() override;
-    void write_state(light::LightState *state) override;
-};
-
-class GroveRedLight : public light::LightOutput,
+class PowerHubLight : public light::LightOutput,
                       public Parented<PowerHub>
 {
-public:
-    light::LightTraits get_traits() override;
-    void write_state(light::LightState *state) override;
-};
+ public:
+  light::LightTraits get_traits() override;
 
-class RS485CANLight : public light::LightOutput,
-                      public Parented<PowerHub>
-{
-public:
-    light::LightTraits get_traits() override;
-    void write_state(light::LightState *state) override;
-};
+  void set_channel(LightChannel channel) { this->channel_ = channel; }
 
-class BATChargeLight : public light::LightOutput,
-                       public Parented<PowerHub>
-{
-public:
-    light::LightTraits get_traits() override;
-    void write_state(light::LightState *state) override;
-};
+  void write_state(light::LightState *state) override;
 
-class PowerLeftLight : public light::LightOutput,
-                       public Parented<PowerHub>
-{
-public:
-    light::LightTraits get_traits() override;
-    void write_state(light::LightState *state) override;
-};
-
-class PowerRightLight : public light::LightOutput,
-                        public Parented<PowerHub>
-{
-public:
-    light::LightTraits get_traits() override;
-    void write_state(light::LightState *state) override;
-};
-
+ protected:
+  LightChannel channel_;
+};                      
     
 } // namespace powerhub
 } // namespace esphome

--- a/components/powerhub/powerhub.cpp
+++ b/components/powerhub/powerhub.cpp
@@ -208,10 +208,16 @@ void PowerHub::setup() {
      * If the user's output voltage is high, 
      * the output current register will be limited to a lower value.
     */
-    uint8_t rs485_can_config[5] = { 0x0B, 0xB8, 0x00, 0x00, 0x00 };
+    // 3000 mV = 0x0BB8: LSB=0xB8, MSB=0x0B (little-endian)
+    uint8_t rs485_can_config[5] = { 0xB8, 0x0B, 0x00, 0x00, 0x00 };
     RETURN_IF_ERROR(this->write_register(Register::REG_VOLT_LSB, 
                                          rs485_can_config, 
                                          sizeof(rs485_can_config)));
+    // Update internal state variables to match the configured values
+    this->rs485_can_voltage_mv_ = 3000;  // Default 3.0V
+    this->rs485_can_current_limit_ = 13;  // Default 13mA
+    this->rs485_can_power_output_ctrl_ = false;
+    this->rs485_can_power_direction_ = false;
 #ifdef USE_NUMBER
     // this->rs485_can_output_voltage_number_->publish_state(3000.0f);
     // this->rs485_can_current_limit_number_->publish_state(13.0f);
@@ -266,17 +272,6 @@ void PowerHub::update() {
 #ifdef USE_SENSOR
    this->update_vameter_sensor();
 #endif
-
-#ifdef USE_TEXT_SENSOR
-    if (this->firmware_ver_text_sensor_) {
-        this->firmware_ver_text_sensor_->publish_state(std::to_string(this->get_firmware_ver()));
-    }
-
-    if(this->bootloader_ver_text_sensor_) {
-        this->bootloader_ver_text_sensor_->publish_state(std::to_string(this->get_bootloader_ver()));
-    }
-#endif
-
 }
 
 
@@ -300,23 +295,10 @@ void PowerHub::dump_config() {
 
 #ifdef USE_TEXT_SENSOR
     ESP_LOGCONFIG(TAG, "Text Sensor:");
-    LOG_TEXT_SENSOR("  ", "Bootloader", this->bootloader_ver_text_sensor_);
     LOG_TEXT_SENSOR("  ", "Charge Status", this->charge_status_text_sensor_);
-    LOG_TEXT_SENSOR("  ", "Firmware", this->firmware_ver_text_sensor_);
     LOG_TEXT_SENSOR("  ", "External Input Power", this->vin_status_text_sensor_);
 #endif
 
-#ifdef USE_SWITCH
-    ESP_LOGCONFIG(TAG, "Switch:");
-    LOG_SWITCH("  ", "LED Power", this->led_pwr_switch_);
-    LOG_SWITCH("  ", "USB Power", this->usb_pwr_switch_);
-    LOG_SWITCH("  ", "Port.A Power (Grove Red)", this->grove_red_pwr_switch_);
-    LOG_SWITCH("  ", "Port.C Power (Grove Blue)", this->grove_blue_pwr_switch_);
-    LOG_SWITCH("  ", "RS485 & CAN Power", this->rs485_can_pwr_switch_);
-    LOG_SWITCH("  ", "RS485 & CAN Power Direction", this->rs485_can_direction_switch_);
-    LOG_SWITCH("  ", "V/A Meter Power", this->vameter_pwr_switch_);
-    LOG_SWITCH("  ", "Charge Power", this->charge_pwr_switch_);
-#endif
 
 #ifdef USE_SELECT
     ESP_LOGCONFIG(TAG, "Select:");
@@ -434,7 +416,7 @@ void PowerHub::set_rs485_can_pwr_direction(bool direction) {
 // 0x00 disable output
 void PowerHub::set_rs485_can_pwr_output(bool output) {
     uint8_t val = output ? 0x01 : 0x00;
-    WARN_IF(this->write_register(Register::REG_PWR_DIR, &val, 1));
+    WARN_IF(this->write_register(Register::REG_PWR_OUTPUT_CTRL, &val, 1));
     this->rs485_can_power_output_ctrl_ = output;
 }
 
@@ -515,6 +497,7 @@ void PowerHub::read_power_channel() {
         this->rs485_.voltage = power.rs485_volt;
         this->rs485_.current = power.rs485_curr;
     }
+    this->power_ = power;
 }
 
 void PowerHub::update_vameter_sensor() {
@@ -617,13 +600,21 @@ uint8_t PowerHub::read_vin_status() {
 void PowerHub::update_charge_vin_sensor() {
 #ifdef USE_TEXT_SENSOR
     if (this->charge_status_text_sensor_) {
-        std::string status = charge_status_to_string(this->read_charge_status());
-        this->charge_status_text_sensor_->publish_state(status);
+        uint8_t charge_status = this->read_charge_status();
+        // Only publish if the value has changed
+        if (charge_status != this->last_charge_status_) {
+            this->charge_status_text_sensor_->publish_state(charge_status_to_string(charge_status));
+            this->last_charge_status_ = charge_status;
+        }
     }
 
     if (this->vin_status_text_sensor_) {
-        std::string status = vin_status_to_string(this->read_vin_status());
-        this->vin_status_text_sensor_->publish_state(status);
+        uint8_t vin_status = this->read_vin_status();
+        // Only publish if the value has changed
+        if (vin_status != this->last_vin_status_) {
+            this->vin_status_text_sensor_->publish_state(vin_status_to_string(vin_status));
+            this->last_vin_status_ = vin_status;
+        }
     }
 #endif 
 }
@@ -719,7 +710,6 @@ void PowerHub::set_brightness_pwr_r(uint8_t b) {
 }
 
 
-
 // Consider adding invert options in YAML
 // 0: press
 // 1: no press
@@ -797,5 +787,5 @@ void PowerHub::sys_download_mode() {
 
 
 
-}    
+} // namespace powerhub
 } // namespace esphome

--- a/components/powerhub/powerhub.h
+++ b/components/powerhub/powerhub.h
@@ -127,20 +127,8 @@ class PowerHub :  public PollingComponent, public i2c::I2CDevice {
 #ifdef USE_TEXT_SENSOR
     SUB_TEXT_SENSOR(charge_status)
     SUB_TEXT_SENSOR(vin_status)
-    SUB_TEXT_SENSOR(firmware_ver)
-    SUB_TEXT_SENSOR(bootloader_ver)
 #endif
 
-#ifdef USE_SWITCH
-    SUB_SWITCH(led_pwr)
-    SUB_SWITCH(usb_pwr)
-    SUB_SWITCH(grove_red_pwr)
-    SUB_SWITCH(grove_blue_pwr)
-    SUB_SWITCH(rs485_can_pwr)
-    SUB_SWITCH(vameter_pwr)
-    SUB_SWITCH(charge_pwr)
-    SUB_SWITCH(rs485_can_direction)
-#endif
 
 #ifdef USE_SELECT
     SUB_SELECT(usb_mode)
@@ -330,6 +318,10 @@ protected:
     // Status
     uint8_t charge_status_;
     uint8_t vin_status_;
+
+    // Cached status for text sensors (to avoid republishing unchanged values)
+    uint8_t last_charge_status_{0xFF};  // Initialize to invalid value
+    uint8_t last_vin_status_{0xFF};
 
     // LED colors
     BGR_t led_usb_c_color_;

--- a/components/powerhub/select/__init__.py
+++ b/components/powerhub/select/__init__.py
@@ -15,7 +15,7 @@ DEPENDENCIES = ["powerhub"]
 CONF_USB_MODE = "usb_mode"
 ICON_USB_PORT = "mdi:usb-port"
 
-USBModeSelect = powerhub_ns.class_("USBModeSelect", select.Select, cg.Component)
+USBModeSelect = powerhub_ns.class_("USBModeSelect", select.Select)
 
 OPTIONS = [
     "Default",
@@ -42,6 +42,5 @@ async def to_code(config):
             usb_mode_conf,
             options=OPTIONS
         )
-        await cg.register_component(var, usb_mode_conf)
         await cg.register_parented(var, powerhub)
         cg.add(powerhub.set_usb_mode_select(var))

--- a/components/powerhub/select/powerhub_select.h
+++ b/components/powerhub/select/powerhub_select.h
@@ -3,26 +3,20 @@
 #include "esphome/components/select/select.h"
 #include "../powerhub.h"
 
-
 namespace esphome {
 namespace powerhub {
 
 class USBModeSelect : public select::Select,
-                       public Component,
                        public Parented<PowerHub>
 {
-
-public:
-    void setup() override {
-        // default state
-        this->publish_state("Default");
+ public:
+  void control(const std::string &value) override {
+    auto index = this->index_of(value);
+    if (index.has_value()) {
+      this->parent_->set_usb_mode(static_cast<uint8_t>(index.value()));
+      this->publish_state(value);
     }
-    void control(const std::string &value) override {
-        this->parent_->set_usb_mode(this->index_of(value).value());
-        this->publish_state(value);
-    }
-
-
+  }
 };
 } // namespace powerhub
 } // namespace esphome

--- a/components/powerhub/switch/__init__.py
+++ b/components/powerhub/switch/__init__.py
@@ -1,12 +1,9 @@
 import esphome.codegen as cg
 import esphome.config_validation as cv
 from esphome.components import switch
-from esphome.cpp_generator import MockObjClass
 from esphome.const import (
-    CONF_ID,
-    ENTITY_CATEGORY_CONFIG,
-    DEVICE_CLASS_SWITCH,
-    ICON_POWER
+    CONF_CHANNEL,
+    ICON_POWER,
 )
 
 from .. import powerhub_ns, BASE_SCHEMA, CONF_POWER_HUB_ID
@@ -14,115 +11,60 @@ from .. import powerhub_ns, BASE_SCHEMA, CONF_POWER_HUB_ID
 CODEOWNERS = ["@m5stack"]
 DEPENDENCIES = ["powerhub"]
 
-CONF_LED_PWR = "led_pwr"
-CONF_USB_PWR = "usb_pwr"
-CONF_GROVE_RED_PWR = "grove_red_pwr"
-CONF_GROVE_BLUE_PWR = "grove_blue_pwr"
-CONF_RS485_CAN_PWR = "rs485_can_pwr"
-CONF_VAMETER_PWR = "vameter_pwr"
-CONF_CHARGE_PWR = "charge_pwr"
-
-# CONF_RS485_CAN_OUTPUT = "rs485_can_output"
-CONF_RS485_CAN_DIRECTION = "rs485_can_direction"
-
-CONF_RTC_WAKE_UP = "rtc_wake_up"
-CONF_VIN_WAKE_UP = "vin_wake_up"
-CONF_VUSB_WAKE_UP = "vusb_wake_up"
-
 ICON_EXPORT = "mdi:export"
-ICON_BED_CLOCK = "mdi:bed-clock"
 
-# power channel
-LEDSwitch = powerhub_ns.class_("LEDSwitch", cg.Component, switch.Switch)
-USBSwitch = powerhub_ns.class_("USBSwitch", switch.Switch, cg.Component)
-GroveRedSwitch = powerhub_ns.class_("GroveRedSwitch", switch.Switch, cg.Component)
-GroveBlueSwitch = powerhub_ns.class_("GroveBlueSwitch", switch.Switch, cg.Component)
-RS485CANSwitch = powerhub_ns.class_("RS485CANSwitch", switch.Switch, cg.Component)
-VAmeterSwitch = powerhub_ns.class_("VAMeterSwitch", switch.Switch, cg.Component)
-ChargeSwitch = powerhub_ns.class_("ChargeSwitch", switch.Switch, cg.Component)
+# General Power switch on powerhub
+PowerSwitch = powerhub_ns.class_("PowerSwitch", switch.Switch, cg.Component)
 
-# RS485 CAN interface power direction control
-# ON:  RS485 / CAN interface will power the external device
-# OFF: RS485 / CAN interface won't power the external device
-DirectionSwitch = powerhub_ns.class_("DirectionSwitch", switch.Switch, cg.Component)
+# The RS485/CAN power direction switch
+RS485CANDirSwitch = powerhub_ns.class_("RS485CANDirSwitch", switch.Switch, cg.Component)
+PowerChannel = powerhub_ns.enum("PowerChannel", is_class=True)
 
-# wake up source
-RTCWakeUpSwitch = powerhub_ns.class_("RTCWakeUpSwitch", switch.Switch, cg.Component)
-VINWakeUpSwitch = powerhub_ns.class_("VINWakeUpSwitch", switch.Switch, cg.Component)
-VUSBWakeUpSwitch = powerhub_ns.class_("VUSBWakeUpSwitch", switch.Switch, cg.Component)
+POWER_CHANNEL = {
+    "LED":        PowerChannel.POWER_LED,
+    "USB":        PowerChannel.POWER_USB,
+    "GROVE_RED":  PowerChannel.POWER_GROVE_RED,
+    "GROVE_BLUE": PowerChannel.POWER_GROVE_BLUE,
+    "RS485_CAN":  PowerChannel.POWER_RS485_CAN,
+    "VAMETER":    PowerChannel.POWER_VAMETER,
+    "CHARGE":     PowerChannel.POWER_CHARGE,
+}
 
+CONF_RS485_CAN_DIR = "rs485_can_dir"
+ICON_ARROW_LEFT_RIGHT = "mdi:arrow-left-right"
 
-CONFIG_SCHEMA = cv.Schema(
-    {
-        cv.Optional(CONF_LED_PWR): switch.switch_schema(
-            LEDSwitch,
-            device_class=DEVICE_CLASS_SWITCH,
-            icon=ICON_POWER,
-            default_restore_mode="RESTORE_DEFAULT_ON"
-        ),
-        cv.Optional(CONF_USB_PWR): switch.switch_schema(
-            USBSwitch,
-            device_class=DEVICE_CLASS_SWITCH,
-            icon=ICON_POWER,
-            default_restore_mode="RESTORE_DEFAULT_OFF"
-        ),
-        cv.Optional(CONF_GROVE_RED_PWR): switch.switch_schema(
-            GroveRedSwitch,
-            device_class=DEVICE_CLASS_SWITCH,
-            icon=ICON_POWER,
-            default_restore_mode="RESTORE_DEFAULT_OFF"
-        ),
-        cv.Optional(CONF_GROVE_BLUE_PWR): switch.switch_schema(
-            GroveBlueSwitch,
-            device_class=DEVICE_CLASS_SWITCH,
-            icon=ICON_POWER,
-            default_restore_mode="RESTORE_DEFAULT_OFF"
-        ),
-        cv.Optional(CONF_RS485_CAN_PWR): switch.switch_schema(
-            RS485CANSwitch,
-            device_class=DEVICE_CLASS_SWITCH,
-            icon=ICON_POWER,
-            default_restore_mode="RESTORE_DEFAULT_OFF"
-        ),
-        cv.Optional(CONF_VAMETER_PWR): switch.switch_schema(
-            VAmeterSwitch,
-            device_class=DEVICE_CLASS_SWITCH,
-            icon=ICON_POWER,
-            default_restore_mode="RESTORE_DEFAULT_ON"
-        ),
-        cv.Optional(CONF_CHARGE_PWR): switch.switch_schema(
-            ChargeSwitch,
-            device_class=DEVICE_CLASS_SWITCH,
-            icon=ICON_POWER,
-            default_restore_mode="RESTORE_DEFAULT_ON"
-        ),
-        cv.Optional(CONF_RS485_CAN_DIRECTION): switch.switch_schema(
-            DirectionSwitch,
-            device_class=DEVICE_CLASS_SWITCH,
-            icon=ICON_EXPORT,
-            default_restore_mode="RESTORE_DEFAULT_OFF"
-        ),
-    }
+POWER_SWITCH_SCHEMA = cv.Schema(
+    switch.switch_schema(
+        PowerSwitch,
+        icon=ICON_POWER,
+    )
+    .extend(
+        {
+            cv.Required(CONF_CHANNEL): cv.enum(POWER_CHANNEL),
+        }
+    )
+    .extend(BASE_SCHEMA)
+    .extend(cv.COMPONENT_SCHEMA)
+)
 
-).extend(BASE_SCHEMA)
+RS485_CAN_DIR_SCHEMA = cv.Schema(
+    switch.switch_schema(
+        RS485CANDirSwitch,
+        icon=ICON_ARROW_LEFT_RIGHT
+    )
+    .extend(BASE_SCHEMA)
+    .extend(cv.COMPONENT_SCHEMA)
+)
+
+def CONFIG_SCHEMA(config):
+    if CONF_CHANNEL in config:
+        return POWER_SWITCH_SCHEMA(config)
+    return RS485_CAN_DIR_SCHEMA(config)
 
 
 async def to_code(config):
-
-    powerhub = await cg.get_variable(config[CONF_POWER_HUB_ID])
-
-    for switch_type in [
-        CONF_LED_PWR, 
-        CONF_USB_PWR, 
-        CONF_GROVE_RED_PWR, 
-        CONF_GROVE_BLUE_PWR, 
-        CONF_RS485_CAN_PWR, 
-        CONF_VAMETER_PWR, 
-        CONF_CHARGE_PWR,
-        CONF_RS485_CAN_DIRECTION
-    ]:
-        if conf := config.get(switch_type):
-            var = await switch.new_switch(conf)
-            await cg.register_component(var, conf)
-            await cg.register_parented(var, powerhub)
-            cg.add(getattr(powerhub, f"set_{switch_type}_switch")(var))
+    var = await switch.new_switch(config)
+    await cg.register_component(var, config)
+    await cg.register_parented(var, config[CONF_POWER_HUB_ID])
+    if CONF_CHANNEL in config:
+        cg.add(var.set_channel(config[CONF_CHANNEL]))

--- a/components/powerhub/switch/powerhub_switch.cpp
+++ b/components/powerhub/switch/powerhub_switch.cpp
@@ -1,0 +1,97 @@
+
+#include "powerhub_switch.h"
+#include "esphome/core/progmem.h"
+#include "esphome/core/log.h"
+
+namespace esphome {
+namespace powerhub {
+
+static const char *TAG = "powerhub.switch";
+
+#if ESPHOME_LOG_LEVEL >= ESPHOME_LOG_LEVEL_DEBUG
+PROGMEM_STRING_TABLE(PowerChannelStrings,
+  "LED",
+  "USB",
+  "Grove Red Port",
+  "Grove Blue Port",
+  "RS485 CAN",
+  "VAMeter",
+  "Charge",
+  "Unknown"
+);
+
+static const LogString *power_channel_to_str(PowerChannel channel) {
+  return PowerChannelStrings::get_log_str(static_cast<uint8_t>(channel), -1);
+}
+#endif
+
+void PowerSwitch::setup() {
+  bool initial_state = this->get_initial_state_with_restore_mode().value_or(false);
+  if (initial_state) {
+    this->turn_on();
+  } else {
+    this->turn_off();
+  }
+}
+
+
+void PowerSwitch::dump_config() {
+  ESP_LOGCONFIG(TAG, "Channel %s\n"
+                      "State %s", 
+                      LOG_STR_ARG(power_channel_to_str(this->channel_)),
+                      ONOFF(this->state));
+  LOG_SWITCH("  ",  "Power Switch", this);
+}
+
+void PowerSwitch::write_state(bool state) {
+  switch (this->channel_) {
+    case PowerChannel::POWER_LED:
+      this->parent_->set_led_pwr_en(state);
+      break;
+    case PowerChannel::POWER_USB:
+      this->parent_->set_usb_pwr_en(state);
+      break;
+    case PowerChannel::POWER_GROVE_RED:
+      this->parent_->set_grove_red_pwr_en(state);
+      break;
+    case PowerChannel::POWER_GROVE_BLUE:
+      this->parent_->set_grove_blue_pwr_en(state);
+      break;
+    case PowerChannel::POWER_RS485_CAN:
+      this->parent_->set_rs485_can_pwr_en(state);
+      break;
+    case PowerChannel::POWER_VAMETER:
+      this->parent_->set_vameter_pwr_en(state);
+      break;
+    case PowerChannel::POWER_CHARGE:
+      this->parent_->set_charge_pwr_en(state);
+      break;
+    default:
+      ESP_LOGW(TAG, "Unknown power channel");
+  }
+  this->publish_state(state);
+}
+
+
+void RS485CANDirSwitch::setup() {
+  bool initial_state = this->get_initial_state_with_restore_mode().value_or(false);
+  if (initial_state) {
+    this->turn_on();
+  } else {
+    this->turn_off();
+  }
+}
+
+void RS485CANDirSwitch::dump_config() {
+  ESP_LOGCONFIG(TAG, "RS485 CAN Output Direction: %s", ONOFF(this->state));
+  LOG_SWITCH("  ", "RS485 CAN Direction Switch", this);  
+}
+
+void RS485CANDirSwitch::write_state(bool state) {
+  this->parent_->set_rs485_can_pwr_direction(state);
+  this->publish_state(state);
+}
+
+} // namespace powerhub
+} // namespace esphome
+

--- a/components/powerhub/switch/powerhub_switch.h
+++ b/components/powerhub/switch/powerhub_switch.h
@@ -2,170 +2,46 @@
 
 #include "esphome/components/switch/switch.h"
 #include "../powerhub.h"
+
+
+
 namespace esphome {
 namespace powerhub {
 
-class LEDSwitch : public switch_::Switch,
-                  public Component,
-                  public Parented<PowerHub>
-{
-
-public:
-    void setup() override {
-        bool initial_state = this->get_initial_state_with_restore_mode().value_or(false);
-        if (initial_state) {
-            this->turn_on();
-        } else {
-            this->turn_off();
-        }
-    }
-    void write_state(bool state) override {
-        this->parent_->set_led_pwr_en(state);
-        this->publish_state(state);
-    }
-
+enum class PowerChannel {
+  POWER_LED,
+  POWER_USB,
+  POWER_GROVE_RED,
+  POWER_GROVE_BLUE,
+  POWER_RS485_CAN,
+  POWER_VAMETER,
+  POWER_CHARGE,
 };
 
-class USBSwitch : public switch_::Switch,
-                  public Component,
-                  public Parented<PowerHub>
-{
-public:
-    void setup() override {
-        bool initial_state = this->get_initial_state_with_restore_mode().value_or(false);
-        if (initial_state) {
-            this->turn_on();
-        } else {
-            this->turn_off();
-        }
-    }
 
-    void write_state(bool state) override {
-        this->parent_->set_usb_pwr_en(state);
-        this->publish_state(state);
-    }
+class PowerSwitch : public switch_::Switch,
+                    public Component,
+                    public Parented<PowerHub>
+{
+ public:
+  void set_channel(PowerChannel channel) { this->channel_ = channel; }
+  void setup() override;
+  void dump_config() override;
+ protected:
+  void write_state(bool state) override;
+  PowerChannel channel_;
 };
 
-class GroveRedSwitch : public switch_::Switch,
-                       public Component,
-                       public Parented<PowerHub>
+
+class RS485CANDirSwitch : public switch_::Switch,
+                          public Component,
+                          public Parented<PowerHub>
 {
-public:
-    void setup() override {
-        bool initial_state = this->get_initial_state_with_restore_mode().value_or(false);
-        if (initial_state) {
-            this->turn_on();
-        } else {
-            this->turn_off();
-        }
-    }
-
-    void write_state(bool state) override {
-        this->parent_->set_grove_red_pwr_en(state);
-        this->publish_state(state);
-    }
-};
-
-class GroveBlueSwitch : public switch_::Switch,
-                        public Component,
-                        public Parented<PowerHub>
-{
-public:
-    void setup() override {
-        bool initial_state = this->get_initial_state_with_restore_mode().value_or(false);
-        if (initial_state) {
-            this->turn_on();
-        } else {
-            this->turn_off();
-        }
-    }
-
-    void write_state(bool state) override {
-        this->parent_->set_grove_blue_pwr_en(state);
-        this->publish_state(state);
-    }
-};
-
-class RS485CANSwitch : public switch_::Switch,
-                       public Component,
-                       public Parented<PowerHub>
-{
-public:
-    void setup() override {
-        bool initial_state = this->get_initial_state_with_restore_mode().value_or(false);
-        if (initial_state) {
-            this->turn_on();
-        } else {
-            this->turn_off();
-        }
-    }
-
-    void write_state(bool state) override {
-        this->parent_->set_rs485_can_pwr_en(state);
-        this->publish_state(state);
-    }
-};
-
-class VAMeterSwitch : public switch_::Switch,
-                      public Component,
-                      public Parented<PowerHub>
-{
-public:
-    void setup() override {
-        bool initial_state = this->get_initial_state_with_restore_mode().value_or(false);
-        if (initial_state) {
-            this->turn_on();
-        } else {
-            this->turn_off();
-        }
-    }
-
-    void write_state(bool state) override {
-        this->parent_->set_vameter_pwr_en(state);
-        this->publish_state(state);
-    }
-};
-
-class ChargeSwitch : public switch_::Switch,
-                     public Component,
-                     public Parented<PowerHub>
-{
-public:
-    void setup() override {
-        bool initial_state = this->get_initial_state_with_restore_mode().value_or(false);
-        if (initial_state) {
-            this->turn_on();
-        } else {
-            this->turn_off();
-        }
-    }
-
-    void write_state(bool state) override {
-        this->parent_->set_charge_pwr_en(state);
-        this->publish_state(state);
-    }
-
-};
-
-class DirectionSwitch : public switch_::Switch,
-                        public Component,
-                        public Parented<PowerHub>
-{
-public:
-    void setup() override {
-        bool initial_state = this->get_initial_state_with_restore_mode().value_or(false);
-        if (initial_state) {
-            this->turn_on();
-        } else {
-            this->turn_off();
-        }
-    }
-
-    void write_state(bool state) override {
-        this->parent_->set_rs485_can_pwr_output(state);
-        this->parent_->set_rs485_can_pwr_direction(state);
-        this->publish_state(state);
-    }
+ public:
+  void setup() override;
+  void dump_config() override;
+ protected:
+  void write_state(bool state) override;
 };
 
 } // namespace powerhub

--- a/components/powerhub/text_sensor/__init__.py
+++ b/components/powerhub/text_sensor/__init__.py
@@ -26,17 +26,8 @@ CONFIG_SCHEMA = (
             ),
             cv.Optional(CONF_VIN_STATUS) : text_sensor.text_sensor_schema(
                 icon=ICON_POWER_PLUG,
-            ),
-            cv.Optional(CONF_FIRMWARE_VER): text_sensor.text_sensor_schema(
-                icon=ICON_CHIP,
-                entity_category=ENTITY_CATEGORY_DIAGNOSTIC
-            ),
-            cv.Optional(CONF_BOOTLOADER_VER): text_sensor.text_sensor_schema(
-                icon=ICON_CHIP,
-                entity_category=ENTITY_CATEGORY_DIAGNOSTIC
             )
         }
-
     )
     .extend(BASE_SCHEMA)
     .extend(cv.polling_component_schema("10s"))
@@ -54,11 +45,3 @@ async def to_code(config):
     if CONF_VIN_STATUS in config:
         ts = await text_sensor.new_text_sensor(config[CONF_VIN_STATUS])
         cg.add(powerhub.set_vin_status_text_sensor(ts))
-    
-    if CONF_FIRMWARE_VER in config:
-        ts = await text_sensor.new_text_sensor(config[CONF_FIRMWARE_VER])
-        cg.add(powerhub.set_firmware_ver_text_sensor(ts))
-
-    if CONF_BOOTLOADER_VER in config:
-        ts = await text_sensor.new_text_sensor(config[CONF_BOOTLOADER_VER])
-        cg.add(powerhub.set_bootloader_ver_text_sensor(ts))

--- a/components/powerhub/time/__init__.py
+++ b/components/powerhub/time/__init__.py
@@ -35,6 +35,7 @@ CONFIG_SCHEMA = time.TIME_SCHEMA.extend(
             cv.GenerateID(): cv.use_id(PowerHubTime),
         }
     ),
+    synchronous=True,
 )
 async def powerhub_write_time_to_code(config, action_id, template_arg, args):
     var = cg.new_Pvariable(action_id, template_arg)
@@ -49,6 +50,7 @@ async def powerhub_write_time_to_code(config, action_id, template_arg, args):
             cv.GenerateID(): cv.use_id(PowerHubTime),
         }
     ),
+    synchronous=True,
 )
 async def powerhub_read_time_to_code(config, action_id, template_arg, args):
     var = cg.new_Pvariable(action_id, template_arg)

--- a/components/powerhub/time/powerhub_time.cpp
+++ b/components/powerhub/time/powerhub_time.cpp
@@ -58,7 +58,7 @@ void PowerHubTime::read_time() {
                   (2000 + time.rtc_year),
                   time.rtc_month,
                   time.rtc_day,
-                  reg_val_to_weekday(time.rtc_weekday));
+                  LOG_STR_ARG(reg_val_to_weekday(time.rtc_weekday)));
 
     ESPTime rtc_time{
         .second        = time.rtc_sec,
@@ -110,7 +110,7 @@ void PowerHubTime::write_time() {
                   time.rtc_year + 2000,
                   time.rtc_month,
                   time.rtc_day,
-                  reg_val_to_weekday(time.rtc_weekday));
+                  LOG_STR_ARG(reg_val_to_weekday(time.rtc_weekday)));
 
     this->parent_->set_rtc_time(time);
 }

--- a/components/scs9009/README.md
+++ b/components/scs9009/README.md
@@ -68,7 +68,7 @@ ftservo:
 
 ## Sensor
 
-Servo telemetry is provided by the [FTServo sensor platform](../ftservo/README.md#sensor). Reference the servo `id` from the `scs9009_servo` declaration.
+Servo telemetry is provided by the [FTServo sensor platform](../ftservo/README.md#sensor). Reference the servo `id` from the `ftservo` declaration.
 
 ```yaml
 sensor:
@@ -204,7 +204,7 @@ scs9009:
   id: scs9009_bus
   uart_id: uart_bus
 
-scs9009_servo:
+ftservo:
   - id: servo_1
     scs9009_id: scs9009_bus
     address: 1

--- a/examples/Switch/atom-socket.factory.yaml
+++ b/examples/Switch/atom-socket.factory.yaml
@@ -1,6 +1,10 @@
 esphome:
   name: atom-socket
   friendly_name: M5Stack Atom Socket
+  name_add_mac_suffix: true
+  project:
+    name: m5stack.atom-socket
+    version: 2026.3.0
 
 esp32:
   variant: esp32
@@ -12,24 +16,20 @@ logger:
 
 # Enable Home Assistant API
 api:
-  encryption:
-    key: "c9+hAXu4wOL2jczsnhePdUkMzKtMznmiwHEiVTF6yII=" # example key, you are supposed to generate a new one
 
 ota:
   - platform: esphome
-    password: "617e76c27db9d7fe1935dc6e7cae10ed" # example passwd, you are supposed to generate a new one
 
 wifi:
-  ssid: !secret wifi_ssid
-  password: !secret wifi_password
-
-  # Enable fallback hotspot (captive portal) in case wifi connection fails
   ap:
-    ssid: "Atom-Socket Fallback Hotspot"
-    password: "Q0a7y5p3O1LS"
 
 captive_portal:
-  
+
+improv_serial:
+
+esp32_improv:
+  authorizer: none
+
 uart:
   rx_pin: GPIO22
   baud_rate: 4800

--- a/examples/camera/unit-poe-cam-w-v1-rev1.facotry.yaml
+++ b/examples/camera/unit-poe-cam-w-v1-rev1.facotry.yaml
@@ -1,0 +1,13 @@
+packages:
+  m5stack-unit-poe-cam: !include ../../common/unit-poe-cam-w-v1-rev1-base.yaml
+
+esphome:
+  project:
+    name: m5stack.m5stack-unit-poe-cam
+    version: 2026.3.0
+
+dashboard_import:
+  package_import_url: github://m5stack/esphome-yaml/common/unit-poe-cam-w-v1-rev1-base.yaml@main
+
+# Since only Ethernet was used, no 'improv via serial' or 'improv via ble' was used
+# You can either enable Wi-Fi or Ethernet

--- a/examples/kit/powerhub.factory.yaml
+++ b/examples/kit/powerhub.factory.yaml
@@ -1,11 +1,14 @@
 esphome:
   name: powerhub
   friendly_name: M5Stack PowerHub
-  min_version: 2025.5.0
+  name_add_mac_suffix: true
   on_boot:
     then:
       # read the RTC time once when the system boots
       powerhub.read_time:
+  project:
+    name: m5stack.powerhub
+    version: 2026.3.0
 
 esp32:
   variant: esp32s3
@@ -20,28 +23,31 @@ psram:
 logger:
   level: DEBUG
 
-wifi:
-  ssid: !secret wifi_ssid
-  password: !secret wifi_password
+improv_serial:
 
-  # Enable fallback hotspot (captive portal) in case wifi connection fails
+esp32_improv:
+  authorizer: none
+
+wifi:
+  on_connect:
+    - delay: 5s  # Gives time for improv results to be transmitted
+    - ble.disable:
+  on_disconnect:
+    - ble.enable:
   ap:
-    ssid: "powerhub"
-    password: ""
+
+captive_portal:
 
 api:
-  encryption:
-    key: "STm5aLUIckeHqTZotQPVzgiA4Vz8ju6ZZXux+z+3TVQ=" # example key, you are supposed to generate a new one
 
 ota:
   - platform: esphome
-    # Replace the key by your OTA key
-    password: "86211424946831287ed4bef6aa32a41b" # example passwd, you are supposed to generate a new one
 
 i2c:
-  sda: GPIO45
+  sda:
+    number: GPIO45
+    ignore_strapping_warning: true
   scl: GPIO48
-
 
 uart:
   - id: rs485_bus
@@ -55,7 +61,7 @@ uart:
 
 
 external_components:
-  - source: github://m5stack/esphome-yaml/components
+  - source: github://m5stack/esphome-yaml/components@main
     components: powerhub
     refresh: 0s
 
@@ -118,27 +124,25 @@ text_sensor:
     vin_status:
       name: "External Input Power Status"
       id: ext_vin_status_text_sensor
-    firmware_ver:
-      name: "Internal Firmware Version"
-      id: int_firm_ver_text_sensor
-    bootloader_ver:
-      name: "Bootloader Version"
-      id: boot_ver_text_sensor
-  
-  - platform: version
-    name: "ESPHome Version"
+
 
 sensor:
   - platform: powerhub
     battery_voltage:
       name: "Battery Voltage"
       id: bat_volt_sensor
+      filters:
+        - delta: 50  # Only publish if voltage changes by 50mV
     battery_current:
       name: "Battery Current"
       id: bat_curr_sensor
+      filters:
+        - delta: 20  # Only publish if current changes by 20mA
     battery_level:
       name: "Battery Percentage"
       id: bat_level_sensor
+      filters:
+        - delta: 1  # Only publish if battery level changes by 1%
       on_value:
         - lambda: |-
             auto call_1 = id(led_pwr_l).turn_on();
@@ -197,111 +201,137 @@ sensor:
     grove_red_voltage:
       name: "Port.A Voltage"
       id: grove_red_volt_sensor
+      filters:
+        - delta: 50  # Only publish if voltage changes by 50mV
     grove_red_current:
       name: "Port.A Current"
       id: grove_red_curr_sensor
+      filters:
+        - delta: 20  # Only publish if current changes by 20mA
     grove_blue_voltage:
       name: "Port.C Voltage"
       id: grove_blue_volt_sensor
+      filters:
+        - delta: 50  # Only publish if voltage changes by 50mV
     grove_blue_current:
       name: "Port.C Current"
       id: grove_blue_curr_sensor
+      filters:
+        - delta: 20  # Only publish if current changes by 20mA
     can_voltage:
       name: "CAN Voltage"
       id: can_volt_sensor
+      filters:
+        - delta: 50  # Only publish if voltage changes by 50mV
     can_current:
       name: "CAN Current"
       id: can_curr_sensor
+      filters:
+        - delta: 20  # Only publish if current changes by 20mA
     rs485_voltage:
       name: "RS485 Voltage"
       id: rs485_volt_sensor
+      filters:
+        - delta: 50  # Only publish if voltage changes by 50mV
     rs485_current:
       name: "RS485 Current"
       id: rs485_curr_sensor
+      filters:
+        - delta: 20  # Only publish if current changes by 20mA
     usb_voltage:
       name: "USB Voltage"
       id: usb_volt_sensor
+      filters:
+        - delta: 50  # Only publish if voltage changes by 50mV
     usb_current:
       name: "USB Current"
       id: usb_curr_sensor
+      filters:
+        - delta: 20  # Only publish if current changes by 20mA
 
 
 switch:
   - platform: powerhub
-    led_pwr:
-      name: "LED Power"
-      id: led_pwr_switch
-      restore_mode: RESTORE_DEFAULT_ON
-    usb_pwr:
-      name: "USB Power"
-      id: usb_pwr_switch
-      on_turn_on:
-        - light.turn_on:
-            id: led_usb_a
-            brightness: 90%
-            # Color maybe
-            # red: 100%
-            # green: 100%
-            # blue: 100%
-        - light.turn_on:
-            id: led_usb_c
-            brightness: 90%
-      on_turn_off:
-        - light.turn_off:
-            id: led_usb_a
-        - light.turn_off:
-            id: led_usb_c
+    channel: LED
+    name: "LED Power"
+    id: led_pwr_switch
+    restore_mode: RESTORE_DEFAULT_ON
 
-    grove_red_pwr:
-      name: "Port.A Power"
-      id: grove_red_pwr_switch
-      on_turn_on:
-        - light.turn_on:
-            id: led_grove_red
-            brightness: 90%
-      on_turn_off:
-        - light.turn_off:
-            id: led_grove_red
+  - platform: powerhub
+    channel: USB
+    name: "USB Power"
+    id: usb_pwr_switch
+    on_turn_on:
+      - light.turn_on:
+          id: led_usb_a
+          brightness: 90%
+      - light.turn_on:
+          id: led_usb_c
+          brightness: 90%
+    on_turn_off:
+      - light.turn_off:
+          id: led_usb_a
+      - light.turn_off:
+          id: led_usb_c
 
-    grove_blue_pwr:
-      name: "Port.C Power"
-      id: grove_blue_pwr_switch
-      on_turn_on:
-        - light.turn_on:
-            id: led_grove_blue
-            brightness: 90%
-      on_turn_off:
-        - light.turn_off:
-            id: led_grove_blue
-    rs485_can_pwr:
-      name: "RS485&CAN Power"
-      id: rs485_can_pwr_switch
-      on_turn_on:
-        - light.turn_on:
-            id: led_rs485_can
-            brightness: 90%
-      on_turn_off:
-        - light.turn_off:
-            id: led_rs485_can
-    charge_pwr:
-      name: "Charge Power"
-      id: charge_pwr_switch
-      restore_mode: RESTORE_DEFAULT_ON
-      on_turn_on:
-        - light.turn_on:
-            id: led_bat_charge
-            brightness: 90%
-      on_turn_off:
-        - light.turn_off:
-            id: led_bat_charge
-    rs485_can_direction:
-      name: "RS485&CAN Power Output"
-      id: rs485_can_direction_switch
-    vameter_pwr:
-      name: "VAMeter Power"
-      id: vameter_pwr_switch
-      restore_mode: RESTORE_DEFAULT_ON
+  - platform: powerhub
+    channel: GROVE_RED
+    name: "Port.A Power"
+    id: grove_red_pwr_switch
+    on_turn_on:
+      - light.turn_on:
+          id: led_grove_red
+          brightness: 90%
+    on_turn_off:
+      - light.turn_off:
+          id: led_grove_red
 
+  - platform: powerhub
+    channel: GROVE_BLUE
+    name: "Port.C Power"
+    id: grove_blue_pwr_switch
+    on_turn_on:
+      - light.turn_on:
+          id: led_grove_blue
+          brightness: 90%
+    on_turn_off:
+      - light.turn_off:
+          id: led_grove_blue
+
+  - platform: powerhub
+    channel: RS485_CAN
+    name: "RS485&CAN Power"
+    id: rs485_can_pwr_switch
+    on_turn_on:
+      - light.turn_on:
+          id: led_rs485_can
+          brightness: 90%
+    on_turn_off:
+      - light.turn_off:
+          id: led_rs485_can
+
+  - platform: powerhub
+    channel: CHARGE
+    name: "Charge Power"
+    id: charge_pwr_switch
+    restore_mode: RESTORE_DEFAULT_ON
+    on_turn_on:
+      - light.turn_on:
+          id: led_bat_charge
+          brightness: 90%
+    on_turn_off:
+      - light.turn_off:
+          id: led_bat_charge
+
+  - platform: powerhub
+    channel: VAMETER
+    name: "VAMeter Power"
+    id: vameter_pwr_switch
+    restore_mode: RESTORE_DEFAULT_ON
+
+  - platform: powerhub
+    name: "RS485 CAN Direction"
+    id: rs485_can_dir
 
 
 select:
@@ -321,32 +351,46 @@ number:
 
 light:
   - platform: powerhub
-    usb_c_rgb:
-      id: led_usb_c
-      name: "USB C Light"
-    usb_a_rgb:
-      id: led_usb_a
-      name: "USB A Light"
-    grove_blue_rgb:
-      id: led_grove_blue
-      name: "Port.C Light"
-    grove_red_rgb:
-      id: led_grove_red
-      name: "Port.A Light"
-    rs485_can_rgb:
-      id: led_rs485_can
-      name: "RS485&CAN Light"
-    bat_charge_rgb:
-      id: led_bat_charge
-      name: "Battery Charge Light"
-      effects:
-        - pulse:
-            name: "Slow Pulse"
-            transition_length: 500ms
-            update_interval: 2s
-    pwr_l_rgb:
-      id: led_pwr_l
-      name: "Power L Light"
-    pwr_r_rgb:
-      id: led_pwr_r
-      name: "Power R Light"
+    channel: USB_A
+    name: "USB A Light"
+    id: led_usb_a
+
+  - platform: powerhub
+    channel: USB_C
+    name: "USB C Light"
+    id: led_usb_c
+
+  - platform: powerhub
+    channel: GROVE_BLUE
+    name: "Port.C Light"
+    id: led_grove_blue
+
+  - platform: powerhub
+    channel: GROVE_RED
+    name: "Port.A Light"
+    id: led_grove_red
+
+  - platform: powerhub
+    channel: RS485_CAN
+    name: "RS485&CAN Light"
+    id: led_rs485_can
+
+  - platform: powerhub
+    channel: CHARGE
+    name: "Battery Charge Light"
+    id: led_bat_charge
+    effects:
+      - pulse:
+          name: "Slow Pulse"
+          transition_length: 500ms
+          update_interval: 2s
+
+  - platform: powerhub
+    channel: POWER_LEFT
+    name: "Power L Light"
+    id: led_pwr_l
+
+  - platform: powerhub
+    channel: POWER_RIGHT
+    name: "Power R Light"
+    id: led_pwr_r

--- a/examples/kit/stamplc.factory.yaml
+++ b/examples/kit/stamplc.factory.yaml
@@ -1,0 +1,471 @@
+esphome:
+  name: stamplc
+  friendly_name: 'M5Stack STAMPLC'
+  min_version: 2025.8.0
+  on_boot:
+    - then:
+        rx8130.read_time:
+  project:
+    name: m5stack.stamplc
+    version: 2026.3.0
+
+# Import external components...
+external_components:
+  - source: github://beormund/esphome-m5stamplc@main
+    components: [aw9523]
+
+esp32:
+  flash_size: 8MB
+  variant: ESP32S3
+  framework:
+    type: esp-idf
+
+# Allow Over-The-Air updates
+ota:
+  - platform: esphome
+  - platform: web_server
+
+#Enable logging
+logger:
+
+improv_serial:
+
+esp32_improv:
+  authorizer: none
+
+# Enable Home Assistant API
+api:
+
+wifi:
+  id: wifi_1
+  on_connect:
+    then:
+      - component.update: vdu
+      - select.set:
+          id: select_led_color
+          option: "Green"
+  on_disconnect:
+    then:
+      - component.update: vdu
+      - select.set:
+          id: select_led_color
+          option: "Red"   
+  ap:
+
+# To have a HA style local web page for device monitoring
+# web_server:
+#   port: 80
+#   version: 3
+#   log: true
+#   local: true
+
+captive_portal:
+
+# Time
+time:
+  - platform: rx8130
+    id: rx8130_time
+    update_interval: 30 min
+    on_time_sync:
+      then:
+        - component.update: vdu
+  - platform: sntp
+    id: sntp_time
+    timezone: Europe/London
+    on_time_sync:
+      then:
+        - rx8130.write_time:
+            id: rx8130_time
+        - component.update: vdu
+    on_time:
+      - cron: '0 * * * * *'
+        then:
+          - component.update: vdu
+
+i2c:
+  sda: GPIO13
+  scl: GPIO15
+  scan: false
+
+spi:
+  clk_pin: GPIO7
+  mosi_pin: GPIO8
+  miso_pin: GPIO9
+
+# RS485 pin config
+uart:
+  tx_pin:
+    number: GPIO0
+    ignore_strapping_warning: true
+  rx_pin: GPIO39
+  baud_rate: 9600
+  parity: EVEN
+
+globals:
+  - id: double_beep
+    type: std::string
+    max_restore_data_length: 34
+    initial_value: '"two_short:d=4,o=5,b=100:16e6,16e6"'
+
+# <--- Keep this section in this order --->
+
+# Set pin 3 high on boot for aw9523 and
+# pi4ioe5v6408 to initialise correctly. 
+power_supply:
+  id: pin3_output_high
+  pin: 
+    number: 3
+    ignore_strapping_warning: true
+  enable_on_boot: true
+# Configuration of i2c GPIO Expander 1 
+pi4ioe5v6408:
+  - id: pi4ioe5v6408_1
+    address: 0x43
+# Configuration of i2c GPIO Expander 2
+aw9523:
+  - id: aw9523_1
+    address: 0x59
+
+# <--- End of ordered section --->
+
+switch:
+  # Relays 1-4
+  - platform: gpio
+    restore_mode: RESTORE_DEFAULT_OFF
+    name: "Relay 1"
+    id: r1
+    pin:
+      aw9523: aw9523_1
+      number: 0
+      mode:
+        output: true
+    on_state:
+      - component.update: vdu
+  - platform: gpio
+    restore_mode: RESTORE_DEFAULT_OFF
+    name: "Relay 2"
+    id: r2
+    pin:
+      aw9523: aw9523_1
+      number: 1
+      mode:
+        output: true
+    on_state:
+      - component.update: vdu
+  - platform: gpio
+    restore_mode: RESTORE_DEFAULT_OFF
+    name: "Relay 3"
+    id: r3
+    pin:
+      aw9523: aw9523_1
+      number: 2
+      mode:
+        output: true
+    on_state:
+      - component.update: vdu
+  - platform: gpio
+    restore_mode: RESTORE_DEFAULT_OFF
+    name: "Relay 4"
+    id: r4
+    pin:
+      aw9523: aw9523_1
+      number: 3
+      mode:
+        output: true
+    on_state:
+      - component.update: vdu
+  # LCD backlight (on/off only)
+  - platform: gpio
+    restore_mode: ALWAYS_ON
+    name: "LCD Backlight"
+    pin:
+      pi4ioe5v6408: pi4ioe5v6408_1
+      number: 7
+      inverted: true
+      mode:
+        output: true
+  # led indicator 3-bit (8 colors only)
+  - platform: gpio
+    restore_mode: ALWAYS_ON
+    id: "led_red"
+    pin:
+      pi4ioe5v6408: pi4ioe5v6408_1
+      number: 6
+      inverted: true
+      mode:
+        output: true
+  - platform: gpio
+    restore_mode: ALWAYS_OFF
+    id: "led_green"
+    pin:
+      pi4ioe5v6408: pi4ioe5v6408_1
+      number: 5
+      inverted: true
+      mode:
+        output: true
+  - platform: gpio
+    restore_mode: ALWAYS_OFF  
+    id: "led_blue"
+    pin:
+      pi4ioe5v6408: pi4ioe5v6408_1
+      number: 4
+      inverted: true
+      mode:
+        output: true
+
+# Enable Web/HA UI to set 3-bit colors for LED Status
+select:
+  - platform: template
+    id: select_led_color
+    name: "Select LED Color"
+    entity_category: config
+    initial_option: Red
+    optimistic: true
+    options:
+      - Black
+      - Red
+      - Green
+      - Yellow
+      - Blue
+      - Magenta
+      - Cyan
+      - White
+    on_value: 
+      then:
+        - switch.control:
+            id: led_red
+            state: !lambda return (i & 1);
+        - switch.control:
+            id: led_green
+            state: !lambda return (i & 2);
+        - switch.control:
+            id: led_blue
+            state: !lambda return (i & 4);
+
+output:
+  # Set up the pwm buzzer on pin 44
+  - platform: ledc
+    pin: GPIO44
+    id: buzzer
+
+rtttl:
+  output: buzzer
+  id: buzzer_1
+
+# Inputs 1-8
+binary_sensor:
+  - platform: gpio
+    id: i1
+    name: "Input 1"
+    pin:
+      aw9523: aw9523_1
+      number: 4
+      mode:
+        input: true
+    on_state:
+      then:
+        - component.update: vdu
+  - platform: gpio
+    id: i2
+    name: "Input 2"
+    pin:
+      aw9523: aw9523_1
+      number: 5
+      mode:
+        input: true
+    on_state:
+      then:
+        - component.update: vdu
+  - platform: gpio
+    id: i3
+    name: "Input 3"
+    pin:
+      aw9523: aw9523_1
+      number: 6
+      mode:
+        input: true
+    on_state:
+      then:
+        - component.update: vdu
+  - platform: gpio
+    id: i4
+    name: "Input 4"
+    pin:
+      aw9523: aw9523_1
+      number: 7
+      mode:
+        input: true
+    on_state:
+      then:
+        - component.update: vdu
+  - platform: gpio
+    id: i5
+    name: "Input 5"
+    pin:
+      aw9523: aw9523_1
+      number: 12
+      mode:
+        input: true
+    on_state:
+      then:
+        - component.update: vdu
+  - platform: gpio
+    id: i6
+    name: "Input 6"
+    pin:
+      aw9523: aw9523_1
+      number: 13
+      mode:
+        input: true
+    on_state:
+      then:
+        - component.update: vdu
+  - platform: gpio
+    id: i7
+    name: "Input 7"
+    pin:
+      aw9523: aw9523_1
+      number: 14
+      mode:
+        input: true
+    on_state:
+      then:
+        - component.update: vdu
+  - platform: gpio
+    id: i8
+    name: "Input 8"
+    pin:
+      aw9523: aw9523_1
+      number: 15
+      mode:
+        input: true
+    on_state:
+      then:
+        - component.update: vdu
+  # Buttons 1-3
+  - platform: gpio
+    name: "Button A"
+    pin:
+      pi4ioe5v6408: pi4ioe5v6408_1
+      number: 2
+      inverted: true
+      mode:
+        input: true
+        pullup: true
+    on_press:
+      - rtttl.play: !lambda return id(double_beep);
+  - platform: gpio
+    name: "Button B"
+    pin:
+      pi4ioe5v6408: pi4ioe5v6408_1
+      number: 1
+      inverted: true
+      mode:
+        input: true
+        pullup: true
+    on_press:
+      - rtttl.play: !lambda return id(double_beep);
+  - platform: gpio
+    name: "Button C"
+    pin:    
+      pi4ioe5v6408: pi4ioe5v6408_1
+      number: 0
+      inverted: true
+      mode:
+        input: true
+        pullup: true
+    on_press:
+      - rtttl.play: !lambda return id(double_beep);
+
+sensor:
+  # INA226 Voltage/Current Sensor on i2c default Address 0x40
+  - platform: ina226
+    shunt_resistance: 0.01
+    max_current: 8.192
+    current:
+      name: "Current"
+      entity_category: "diagnostic"
+    power:
+      name: "Power"
+      entity_category: "diagnostic"
+    bus_voltage:
+      name: "Bus Voltage"
+      entity_category: "diagnostic"
+    shunt_voltage:
+      name: "Shunt Voltage"
+      entity_category: "diagnostic"
+  # LM75B Temp Sensor on i2c default address 0x48 
+  - platform: lm75b
+    name: "Temperature"
+    update_interval: 60s
+    entity_category: "diagnostic"
+
+# Some colors for the LED display
+color:
+  - id: orange
+    hex: fff099
+  - id: grey
+    hex: 3A3B3C
+  - id: blue
+    hex: 9fcff9
+  - id: green
+    hex: 51af73
+  - id: red
+    hex: db6676
+  - id: purple
+    hex: af69e3
+
+display:
+  platform: mipi_spi
+  id: vdu
+  model: ST7789V
+  transform: 
+    swap_xy: True
+    mirror_x: True
+    mirror_y: False
+  dimensions:
+    width: 240
+    height: 240
+    offset_width: 42
+    offset_height: 55
+  dc_pin: GPIO06
+  cs_pin: GPIO12
+  invert_colors: true
+  update_interval: never
+  lambda: |-
+    if (id(rx8130_time).now().is_valid()) {
+      it.strftime(5, 0, id(font1), Color(orange), "%a %d %b %Y  %H:%M  %Z", id(rx8130_time).now()); 
+    }
+    if (id(wifi_1).is_connected()) {
+      it.print(210, 0, id(wifi_icons), id(green), "\uef10");
+    } else {
+      it.print(210, 0, id(wifi_icons), id(red), "\uef13");
+    }
+    it.line(5, 19, 230, 19, id(grey));
+    it.print(5, 28, id(font1), id(orange), "Inputs 1-8");
+    it.filled_rectangle(5, 47, 25, 25, id(i1).state ? id(purple) : id(grey));
+    it.filled_rectangle(34, 47, 25, 25, id(i2).state ? id(purple) : id(grey));
+    it.filled_rectangle(63, 47, 25, 25, id(i3).state ? id(purple) : id(grey));
+    it.filled_rectangle(92, 47, 25, 25, id(i4).state ? id(purple) : id(grey));
+    it.filled_rectangle(121, 47, 25, 25, id(i5).state ? id(purple) : id(grey));
+    it.filled_rectangle(150, 47, 25, 25, id(i6).state ? id(purple) : id(grey));
+    it.filled_rectangle(179, 47, 25, 25, id(i7).state ? id(purple) : id(grey));
+    it.filled_rectangle(208, 47, 25, 25, id(i8).state ? id(purple) : id(grey));
+    it.print(5, 80, id(font1), Color(orange), "Relays 1-4");
+    it.filled_rectangle(5, 99, 25, 25, id(r1).state ? id(red) : id(grey));
+    it.filled_rectangle(34, 99, 25, 25, id(r2).state ? id(red) : id(grey));
+    it.filled_rectangle(63, 99, 25, 25, id(r3).state ? id(red) : id(grey));
+    it.filled_rectangle(92, 99, 25, 25, id(r4).state ? id(red) : id(grey));
+
+font:
+  - file: "gfonts://Roboto"
+    id: font1
+    size: 15
+  - file: "gfonts://Material+Symbols+Outlined"
+    id: wifi_icons
+    size: 18
+    glyphs: [
+      "\uef10", # wifi
+      "\uef13", # no wifi
+    ]  
+  


### PR DESCRIPTION
Following products have been renamed to 'factory.yaml' to build ESPHome factory firmware. Added the `improv_serial` and `esp32_improv` component for network configuration:

- `Unit PoE CAM-w v1.1`
- `PowerHub`
- `StamPLC`
- `Atom Socket`

Refactor the powerhub `switch` and `light`.