### PR TITLE
Fix i2c_joystick_2 failed component mark 

### DIFF
--- a/components/i2c_joystick_2/i2c_joystick_2.cpp
+++ b/components/i2c_joystick_2/i2c_joystick_2.cpp
@@ -21,7 +21,7 @@ void I2CJoystick2Component::setup() {
   ESP_LOGD(TAG, "Setting up I2C Joystick2...");
   // Read firmware version
   if ( !read_u8_(JOYSTICK2_FIRMWARE_VERSION_REG, &this->firmware_version_) ) {
-    this->mark_failed(LOG_STR("Fail to communicate with device"));
+    ESP_LOGW(TAG, "Failed to read firmware version from Joystick2");
     return;
   }
 
@@ -157,18 +157,13 @@ void I2CJoystick2Component::dump_config() {
   ESP_LOGCONFIG(TAG, "I2C Joystick2:");
   LOG_I2C_DEVICE(this);
 
-  if (this->is_failed()) {
-    ESP_LOGE(TAG, "Communication with Joystick2 failed");
-    return;
-  }
-
   ESP_LOGCONFIG(TAG, "I2C Joystick2: \n"
                      "  Firmware version: %u", 
                      this->firmware_version_);
 }
 
 void I2CJoystick2Sensor::update() {
-  if (this->parent_ == nullptr || this->parent_->is_failed()) {
+  if (this->parent_ == nullptr) {
     ESP_LOGW(TAG, "Joystick2 parent component unavailable");
     return;
   }
@@ -192,7 +187,7 @@ void I2CJoystick2Sensor::dump_config() {
 }
 
 void I2CJoystick2BinarySensor::update() {
-  if (this->parent_ == nullptr || this->parent_->is_failed()) {
+  if (this->parent_ == nullptr) {
     ESP_LOGW(TAG, "Joystick2 parent component unavailable");
     return;
   }


### PR DESCRIPTION
This is caused by power sequencing of PowerHub, but some other m5stack devices with dedicated I2C PMU may be affected too. 
Since all of the I2C devices are mostly initialized at the same time the powerhub PMU does not have enough time to stabilize the power going to A and B ports and that means that some I2C peripherals may not be able to initialize right at the start. Changing setup priority does not seem to change much, the issue persists.
Can be reproduced by connecting i2c_joystick_2 to any of the 2 PowerHub ports.
Other more sophisticated solutions are welcome, but just not using the "component failed" flag seems to do the trick.
