### PR TITLE
Set mic channel to LEFT for atoms3r-with-echo-base

### DIFF
--- a/common/atoms3r-with-echo-base.yaml
+++ b/common/atoms3r-with-echo-base.yaml
@@ -183,6 +183,9 @@ microphone:
     i2s_din_pin: GPIO7
     bits_per_sample: 16bit
     adc_type: external
+    channel: left  # ES8311 sends mic samples on the LEFT slot
+                   # (M5Stack OpenAI SDK uses I2S_CHANNEL_FMT_ALL_LEFT;
+                   # ESPHome's i2s_audio.microphone defaults to RIGHT)
 
 
 speaker:


### PR DESCRIPTION
The ES8311 codec on the Atomic Echo Base sends microphone samples on the LEFT I2S slot, but ESPHome's i2s_audio.microphone defaults to RIGHT, the device reads from a silent slot and the mic appears non-functional.

This matches I2S_CHANNEL_FMT_ALL_LEFT in M5Stack's own openai-realtime- embedded-sdk (see [media.cpp, "Important for EchoBase" comment](https://github.com/m5stack/openai-realtime-embedded-sdk/blob/38175369447413c57443a168de90c33fb5444437/src/media.cpp#L146)).

