### PR TITLE
Add powerhub charging binary sensor and optional update intervals

### DIFF
--- a/components/powerhub/binary_sensor/__init__.py
+++ b/components/powerhub/binary_sensor/__init__.py
@@ -8,15 +8,24 @@ from .. import CONF_POWER_HUB_ID, BASE_SCHEMA
 
 DEPENDENCIES = ["powerhub"]
 
+CONF_VIN_STATUS = "vin_status"
+
 # the Top PMU button is a square shape
 ICON_GESTURE_TAP_BUTTON = "mdi:gesture-tap-button"
 
 CONFIG_SCHEMA = (
     cv.Schema(
         {
-            cv.Optional(CONF_BUTTON) : binary_sensor.binary_sensor_schema(
-                icon=ICON_GESTURE_TAP_BUTTON
-            )
+            cv.Optional(CONF_BUTTON): binary_sensor.binary_sensor_schema(icon=ICON_GESTURE_TAP_BUTTON).extend(
+                {
+                    cv.Optional("update_interval", default=20): cv.positive_int,
+                }
+            ),
+            cv.Optional(CONF_VIN_STATUS): binary_sensor.binary_sensor_schema(icon="mdi:power-plug").extend(
+                {
+                    cv.Optional("update_interval", default=500): cv.positive_int,
+                }
+            ),
         }
     )
     .extend(BASE_SCHEMA)
@@ -29,3 +38,9 @@ async def to_code(config):
     if CONF_BUTTON in config:
         sens = await binary_sensor.new_binary_sensor(config[CONF_BUTTON])
         cg.add(powerhub.set_button_binary_sensor(sens))
+        cg.add(powerhub.set_button_update_interval(config[CONF_BUTTON]["update_interval"]))
+
+    if CONF_VIN_STATUS in config:
+        sens = await binary_sensor.new_binary_sensor(config[CONF_VIN_STATUS])
+        cg.add(powerhub.set_vin_status_binary_sensor(sens))
+        cg.add(powerhub.set_vin_status_update_interval(config[CONF_VIN_STATUS]["update_interval"]))

--- a/components/powerhub/powerhub.cpp
+++ b/components/powerhub/powerhub.cpp
@@ -248,17 +248,23 @@ void PowerHub::setup() {
 
 #ifdef USE_BINARY_SENSOR
     // Inteval used to read PMU button status
-    // polling every 20ms
+    // polling every button_update_interval_ ms
     this->button_binary_sensor_->publish_initial_state(false);
-    this->set_interval("pmu_button", 20, [this]() {
+    this->set_interval("pmu_button", this->button_update_interval_, [this]() {
         this->update_pmu_button_sensor();
+    });
+
+    // Interval for VIN status
+    this->vin_status_binary_sensor_->publish_initial_state(false);
+    this->set_interval("vin_status", this->vin_status_update_interval_, [this]() {
+        this->update_vin_status_sensor();
     });
 #endif
 
 #ifdef USE_TEXT_SENSOR
     // Interval used to read charge/vin status
-    // polling every 500 ms (0.5s)
-    this->set_interval("charge_vin_status", 500, [this]() {
+    // polling every charge_status_update_interval_ ms
+    this->set_interval("charge_vin_status", this->charge_status_update_interval_, [this]() {
         this->update_charge_vin_sensor();
     });
 #endif
@@ -284,6 +290,7 @@ void PowerHub::dump_config() {
 #ifdef USE_BINARY_SENSOR
     ESP_LOGCONFIG(TAG, "Binary Sensor:");
     LOG_BINARY_SENSOR("  ", "Button", this->button_binary_sensor_);
+    LOG_BINARY_SENSOR("  ", "VIN Status", this->vin_status_binary_sensor_);
 #endif
 
 #ifdef USE_SENSOR
@@ -727,6 +734,19 @@ void PowerHub::update_pmu_button_sensor() {
         if (pressed != this->last_button_state_) {
             this->last_button_state_ = pressed;
             this->button_binary_sensor_->publish_state(pressed);
+        }
+    }
+#endif
+}
+
+void PowerHub::update_vin_status_sensor() {
+#ifdef USE_BINARY_SENSOR
+    if (this->vin_status_binary_sensor_) {
+        uint8_t vin_status = this->read_vin_status();
+        bool has_input = (vin_status == 1);
+        if (has_input != this->last_vin_state_) {
+            this->last_vin_state_ = has_input;
+            this->vin_status_binary_sensor_->publish_state(has_input);
         }
     }
 #endif

--- a/components/powerhub/powerhub.h
+++ b/components/powerhub/powerhub.h
@@ -105,6 +105,7 @@ class PowerHub :  public PollingComponent, public i2c::I2CDevice {
 
 #ifdef USE_BINARY_SENSOR
     SUB_BINARY_SENSOR(button)
+    SUB_BINARY_SENSOR(vin_status)
 #endif
 
 
@@ -249,6 +250,9 @@ public:
     // Because we need to get the button status fast
     void update_pmu_button_sensor();
 
+    // Update VIN status binary sensor
+    void update_vin_status_sensor();
+
 
     // RTC related
     // Wakeup getters/setters
@@ -281,6 +285,12 @@ public:
     // i2c address
     uint8_t get_i2c_addr() const { return this->i2c_address_; }
 
+    // Set update intervals
+    void set_button_update_interval(uint32_t interval) { this->button_update_interval_ = interval; }
+    void set_charging_status_update_interval(uint32_t interval) { this->vin_status_update_interval_ = interval; }
+    void set_charge_status_update_interval(uint32_t interval) { this->charge_status_update_interval_ = interval; }
+    void set_vin_status_update_interval(uint32_t interval) { this->vin_status_update_interval_ = interval; }
+
 protected:
     // Power enable
     bool led_power_enabled_;
@@ -294,6 +304,9 @@ protected:
 
     // Used to store the last PMU button state
     bool last_button_state_{false};
+
+    // Used to store the last VIN state
+    bool last_vin_state_{false};
 
     // USB mode
     uint8_t usb_mode_;
@@ -322,6 +335,11 @@ protected:
     // Cached status for text sensors (to avoid republishing unchanged values)
     uint8_t last_charge_status_{0xFF};  // Initialize to invalid value
     uint8_t last_vin_status_{0xFF};
+
+    // Update intervals in milliseconds
+    uint32_t button_update_interval_{20};
+    uint32_t charge_status_update_interval_{500};
+    uint32_t vin_status_update_interval_{500};
 
     // LED colors
     BGR_t led_usb_c_color_;

--- a/components/powerhub/text_sensor/__init__.py
+++ b/components/powerhub/text_sensor/__init__.py
@@ -21,16 +21,19 @@ ICON_POWER_PLUG = "mdi:power-plug"
 CONFIG_SCHEMA = (
     cv.Schema(
         {
-            cv.Optional(CONF_CHARGE_STATUS) : text_sensor.text_sensor_schema(
-                icon=ICON_POWER_PLUG_BATTERY,
+            cv.Optional(CONF_CHARGE_STATUS): text_sensor.text_sensor_schema(icon=ICON_POWER_PLUG_BATTERY).extend(
+                {
+                    cv.Optional("update_interval", default=500): cv.positive_int,
+                }
             ),
-            cv.Optional(CONF_VIN_STATUS) : text_sensor.text_sensor_schema(
-                icon=ICON_POWER_PLUG,
-            )
+            cv.Optional(CONF_VIN_STATUS): text_sensor.text_sensor_schema(icon=ICON_POWER_PLUG).extend(
+                {
+                    cv.Optional("update_interval", default=500): cv.positive_int,
+                }
+            ),
         }
     )
     .extend(BASE_SCHEMA)
-    .extend(cv.polling_component_schema("10s"))
 )
 
 
@@ -41,7 +44,9 @@ async def to_code(config):
     if CONF_CHARGE_STATUS in config:
         ts = await text_sensor.new_text_sensor(config[CONF_CHARGE_STATUS])
         cg.add(powerhub.set_charge_status_text_sensor(ts))
+        cg.add(powerhub.set_charge_status_update_interval(config[CONF_CHARGE_STATUS]["update_interval"]))
     
     if CONF_VIN_STATUS in config:
         ts = await text_sensor.new_text_sensor(config[CONF_VIN_STATUS])
         cg.add(powerhub.set_vin_status_text_sensor(ts))
+        cg.add(powerhub.set_vin_status_update_interval(config[CONF_VIN_STATUS]["update_interval"]))


### PR DESCRIPTION
Added PowerHub binary sensor just to make a bit cleaner way to get the charging status without parsing the text sensor in lambdas.

Also noticed that there are no update interval configuration options for the sensors, so added those too.