### PR TITLE
Lock esphome-intercom to v3.1.0

### DIFF
--- a/common/stackchan-voice-assistant-base.yaml
+++ b/common/stackchan-voice-assistant-base.yaml
@@ -170,7 +170,7 @@ external_components:
     components: [micro_wake_word]
     refresh: 1h
 
-  - source: github://n-IA-hane/esphome-intercom
+  - source: github://n-IA-hane/esphome-intercom@v3.1.0
     components: [i2s_audio_duplex, esp_aec]
     refresh: 1h
     


### PR DESCRIPTION
Currently, esphome-intercom is pulling from main.
n-IA-hane/esphome-intercom#1a6f732 changed the `aec_id` field to `processor_id` and v4 adds a new `audio_processor` component that needs to be included.
For now, use esphome-intercom v3.1.0 until further testing can be done with v4.