### PR TITLE
fix: migrate LVGL 8 API calls to LVGL 9

### DIFF
--- a/common/tab5-ha-hmi.yaml
+++ b/common/tab5-ha-hmi.yaml
@@ -547,15 +547,15 @@ text_sensor:
               // disable some UI widgets
               lv_obj_add_state(id(ac_container), LV_STATE_DISABLED);
               lv_obj_add_state(id(temp_spin_down), LV_STATE_DISABLED);
-              lv_obj_clear_flag(id(temp_spin_down), LV_OBJ_FLAG_CLICKABLE);
+              lv_obj_remove_flag(id(temp_spin_down), LV_OBJ_FLAG_CLICKABLE);
               lv_obj_add_state(id(temp_spin_up), LV_STATE_DISABLED);
-              lv_obj_clear_flag(id(temp_spin_up), LV_OBJ_FLAG_CLICKABLE);
+              lv_obj_remove_flag(id(temp_spin_up), LV_OBJ_FLAG_CLICKABLE);
           } else {
               // restore UI widgets
-              lv_obj_clear_state(id(ac_container), LV_STATE_DISABLED);
-              lv_obj_clear_state(id(temp_spin_down), LV_STATE_DISABLED);
+              lv_obj_remove_state(id(ac_container), LV_STATE_DISABLED);
+              lv_obj_remove_state(id(temp_spin_down), LV_STATE_DISABLED);
               lv_obj_add_flag(id(temp_spin_down), LV_OBJ_FLAG_CLICKABLE);
-              lv_obj_clear_state(id(temp_spin_up), LV_STATE_DISABLED);
+              lv_obj_remove_state(id(temp_spin_up), LV_STATE_DISABLED);
               lv_obj_add_flag(id(temp_spin_up), LV_OBJ_FLAG_CLICKABLE);
           }
       - lvgl.dropdown.update:

--- a/common/tab5-scripts.yaml
+++ b/common/tab5-scripts.yaml
@@ -55,7 +55,7 @@ script:
               if (i == id(page_num)) {
                 lv_obj_add_state(buttons[i], LV_STATE_CHECKED);
               } else {
-                lv_obj_clear_state(buttons[i], LV_STATE_CHECKED);
+                lv_obj_remove_state(buttons[i], LV_STATE_CHECKED);
               }
               bool selected = (i == active);
               lv_obj_add_style(labels[i], selected ? id(nav_label_activate) : id(nav_label_inactivate), LV_PART_MAIN);
@@ -129,7 +129,7 @@ script:
               float val = 1.0f;  // fixed brightness
 
               lv_color_t c = hsv_to_rgb(hue, sat, val);
-              lv_canvas_set_px(canvas, x, y, c);
+              lv_canvas_set_px(canvas, x, y, c, LV_OPA_COVER);
             }
           };
   # This script was used to draw a custom 'indicator' on color palette
@@ -148,7 +148,7 @@ script:
     then:
       - lambda: |-
           lv_obj_add_event_cb(id(color_palette_indicator), [](lv_event_t * e){
-            lv_obj_t * obj = lv_event_get_target(e);
+            lv_obj_t * obj = lv_event_get_target_obj(e);
 
             lv_indev_t * indev = lv_indev_get_act();
             if(indev == NULL)  return;


### PR DESCRIPTION
## Summary

ESPHome 2026.4.0 upgraded the bundled LVGL from 8.x to 9.x, which is a breaking API change. The Tab5 scripts currently fail to compile against the new LVGL version with errors like:

```
error: too few arguments to function 'void lv_canvas_set_px(lv_obj_t*, int32_t, int32_t, lv_color_t, lv_opa_t)'
error: invalid conversion from 'void*' to 'lv_obj_t*'
```

This PR migrates the affected calls to the LVGL 9 API:

- `lv_canvas_set_px` — added the now-required `lv_opa_t` opacity argument (`LV_OPA_COVER` for the existing fully-opaque behavior).
- `lv_event_get_target` — switched to `lv_event_get_target_obj`, the LVGL-9-native typed helper. The old name now returns `void *` because the target isn't always an `lv_obj_t` anymore.
- `lv_obj_clear_flag` / `lv_obj_clear_state` — renamed to `lv_obj_remove_flag` / `lv_obj_remove_state`. The old names still work via compat wrappers but were renamed in LVGL 9 and may be dropped in future ESPHome releases.

Files touched:
- `common/tab5-scripts.yaml`
- `common/tab5-ha-hmi.yaml`

No behavioral change — pure API migration.

## Test plan

- [ ] Build the `m5stack-tab5` example against ESPHome 2026.4.0+ and confirm it compiles.
- [ ] Flash to a Tab5 and verify the color palette indicator (uses `lv_event_get_target_obj` and `lv_canvas_set_px`) still tracks touch input and updates the selected color.
- [ ] Verify the AC HMI panel still enables/disables correctly when the bound entity becomes `unavailable` (exercises the `lv_obj_remove_flag` / `lv_obj_remove_state` paths).