### PR TITLE
Add optional gravity-based screen rotation for the CoreS3 (BMI270)

### DIFF
--- a/common/cores3-imu-rotation.yaml
+++ b/common/cores3-imu-rotation.yaml
@@ -14,15 +14,16 @@
 # - Uses ESPHome's native `motion:` hub (BMI270 platform) — no external components.
 # - The CoreS3's BMI270 answers at 0x69 (SDO high), not the 0x68 default.
 # - Only the in-screen-plane Y axis is read: its gravity component changes SIGN
-#   between the two 180°-apart poses. The 0.30 g deadzone keeps the current
-#   orientation when the device lies flat (ambiguous). Portrait (90/270) is not
-#   used — the satellite UI is landscape-only.
+#   between the two 180°-apart poses. `on_value_range` provides the transition
+#   detection and hysteresis natively — the ±0.30 g gap between the bands is the
+#   deadzone, so a device lying flat keeps its current orientation. Portrait
+#   (90/270) is not used — the satellite UI is landscape-only.
 # - mipi_spi applies set_rotation() at runtime (MADCTL is recomputed), so the flip
 #   needs only a redraw, which `component.update` provides.
 # - Touch follows the screen: the touchscreen core doesn't track display rotation at
-#   runtime, so the same lambda mirrors both touch axes when flipped (mirror X + Y
-#   == 180°) via the public set_mirror_x/set_mirror_y setters. Position-sensitive
-#   touch zones keep working in either orientation.
+#   runtime, so each flip also mirrors both touch axes (mirror X + Y == 180°) via
+#   the public set_mirror_x/set_mirror_y setters. Position-sensitive touch zones
+#   keep working in either orientation.
 
 motion:
   - platform: bmi270
@@ -35,37 +36,18 @@ sensor:
     type: acceleration_y
     id: imu_accel_y
     internal: true
-
-globals:
-  - id: imu_orientation
-    type: int
-    restore_value: false
-    initial_value: "0"
-  - id: imu_orientation_applied
-    type: int
-    restore_value: false
-    initial_value: "-1"
-
-interval:
-  - interval: 1s
-    then:
-      - lambda: |-
-          // Gravity decides which way is up; NaN (no reading yet) leaves it alone.
-          float ay = id(imu_accel_y).state;
-          if (!isnan(ay)) {
-            if (ay > 0.30f) id(imu_orientation) = 0;
-            else if (ay < -0.30f) id(imu_orientation) = 180;
-          }
-      - if:
-          condition:
-            lambda: "return id(imu_orientation) != id(imu_orientation_applied);"
-          then:
-            - lambda: |-
-                id(imu_orientation_applied) = id(imu_orientation);
-                const bool flipped = id(imu_orientation) == 180;
-                id(m5cores3_lcd).set_rotation(flipped ? display::DISPLAY_ROTATION_180_DEGREES
-                                                      : display::DISPLAY_ROTATION_0_DEGREES);
-                // Keep touch aligned with the screen: mirror X + Y == rotate 180.
-                id(touch).set_mirror_x(flipped);
-                id(touch).set_mirror_y(flipped);
-            - component.update: m5cores3_lcd
+    on_value_range:
+      - above: 0.30
+        then:
+          - lambda: |-
+              id(m5cores3_lcd).set_rotation(display::DISPLAY_ROTATION_0_DEGREES);
+              id(touch).set_mirror_x(false);
+              id(touch).set_mirror_y(false);
+          - component.update: m5cores3_lcd
+      - below: -0.30
+        then:
+          - lambda: |-
+              id(m5cores3_lcd).set_rotation(display::DISPLAY_ROTATION_180_DEGREES);
+              id(touch).set_mirror_x(true);
+              id(touch).set_mirror_y(true);
+          - component.update: m5cores3_lcd

--- a/common/cores3-imu-rotation.yaml
+++ b/common/cores3-imu-rotation.yaml
@@ -1,0 +1,67 @@
+# Gravity-based screen rotation for the M5Stack CoreS3 / CoreS3-Lite / CoreS3-SE.
+#
+# Optional add-on package for cores3-satellite-base.yaml: reads the on-board BMI270
+# IMU and flips the display between the two landscape orientations (0 / 180) so the
+# screen is always right-side-up, whichever way the device is stood or handed over.
+#
+# Include it alongside the base package:
+#
+#   packages:
+#     m5stack-cores3: !include ../../common/cores3-satellite-base.yaml
+#     imu-rotation:   !include ../../common/cores3-imu-rotation.yaml
+#
+# Notes:
+# - Uses ESPHome's native `motion:` hub (BMI270 platform) — no external components.
+# - The CoreS3's BMI270 answers at 0x69 (SDO high), not the 0x68 default.
+# - Only the in-screen-plane Y axis is read: its gravity component changes SIGN
+#   between the two 180°-apart poses. The 0.30 g deadzone keeps the current
+#   orientation when the device lies flat (ambiguous). Portrait (90/270) is not
+#   used — the satellite UI is landscape-only.
+# - mipi_spi applies set_rotation() at runtime (MADCTL is recomputed), so the flip
+#   needs only a redraw, which `component.update` provides.
+# - The base's on_touch handler is position-agnostic (logging), so no touch
+#   coordinate mirroring is required. If you add position-sensitive touch zones,
+#   mirror x/y when `imu_orientation == 180`.
+
+motion:
+  - platform: bmi270
+    i2c_id: bsp_bus
+    address: 0x69
+    update_interval: 250ms
+
+sensor:
+  - platform: motion
+    type: acceleration_y
+    id: imu_accel_y
+    internal: true
+
+globals:
+  - id: imu_orientation
+    type: int
+    restore_value: false
+    initial_value: "0"
+  - id: imu_orientation_applied
+    type: int
+    restore_value: false
+    initial_value: "-1"
+
+interval:
+  - interval: 1s
+    then:
+      - lambda: |-
+          // Gravity decides which way is up; NaN (no reading yet) leaves it alone.
+          float ay = id(imu_accel_y).state;
+          if (!isnan(ay)) {
+            if (ay > 0.30f) id(imu_orientation) = 0;
+            else if (ay < -0.30f) id(imu_orientation) = 180;
+          }
+      - if:
+          condition:
+            lambda: "return id(imu_orientation) != id(imu_orientation_applied);"
+          then:
+            - lambda: |-
+                id(imu_orientation_applied) = id(imu_orientation);
+                id(m5cores3_lcd).set_rotation(
+                    id(imu_orientation) == 180 ? display::DISPLAY_ROTATION_180_DEGREES
+                                               : display::DISPLAY_ROTATION_0_DEGREES);
+            - component.update: m5cores3_lcd

--- a/common/cores3-imu-rotation.yaml
+++ b/common/cores3-imu-rotation.yaml
@@ -19,9 +19,10 @@
 #   used — the satellite UI is landscape-only.
 # - mipi_spi applies set_rotation() at runtime (MADCTL is recomputed), so the flip
 #   needs only a redraw, which `component.update` provides.
-# - The base's on_touch handler is position-agnostic (logging), so no touch
-#   coordinate mirroring is required. If you add position-sensitive touch zones,
-#   mirror x/y when `imu_orientation == 180`.
+# - Touch follows the screen: the touchscreen core doesn't track display rotation at
+#   runtime, so the same lambda mirrors both touch axes when flipped (mirror X + Y
+#   == 180°) via the public set_mirror_x/set_mirror_y setters. Position-sensitive
+#   touch zones keep working in either orientation.
 
 motion:
   - platform: bmi270
@@ -61,7 +62,10 @@ interval:
           then:
             - lambda: |-
                 id(imu_orientation_applied) = id(imu_orientation);
-                id(m5cores3_lcd).set_rotation(
-                    id(imu_orientation) == 180 ? display::DISPLAY_ROTATION_180_DEGREES
-                                               : display::DISPLAY_ROTATION_0_DEGREES);
+                const bool flipped = id(imu_orientation) == 180;
+                id(m5cores3_lcd).set_rotation(flipped ? display::DISPLAY_ROTATION_180_DEGREES
+                                                      : display::DISPLAY_ROTATION_0_DEGREES);
+                // Keep touch aligned with the screen: mirror X + Y == rotate 180.
+                id(touch).set_mirror_x(flipped);
+                id(touch).set_mirror_y(flipped);
             - component.update: m5cores3_lcd


### PR DESCRIPTION
Adds `common/cores3-imu-rotation.yaml` — an **optional** add-on package for `cores3-satellite-base.yaml` that keeps the satellite's screen right-side-up: the on-board BMI270 is read via ESPHome's native `motion:` hub and the display flips between the two landscape orientations (0/180) from the sign of the in-plane gravity component.

Usage:
```yaml
packages:
  m5stack-cores3: !include ../../common/cores3-satellite-base.yaml
  imu-rotation:   !include ../../common/cores3-imu-rotation.yaml
```

Design notes:
- **No changes to the base** — purely additive include; no external components (native `motion:`/`bmi270`, min ESPHome 2026.1 already required by the base).
- CoreS3's BMI270 answers at **0x69** (not the 0x68 default), on `bsp_bus`.
- **Native trigger semantics, minimal code**: `on_value_range` on the acceleration-Y sensor provides transition detection and hysteresis — the gap between the ±0.30 g bands is the deadzone, so a device lying flat keeps its current orientation. No globals, no polling interval; the only lambdas are the irreducible `set_rotation` + touch-mirror calls.
- `mipi_spi` recomputes MADCTL in `set_rotation()` at runtime, so the flip only needs the `component.update` redraw.
- **Touch stays aligned with the screen**: the touchscreen core doesn't track display rotation at runtime, so each flip also mirrors both touch axes (mirror X + Y == 180°) via the public `set_mirror_x`/`set_mirror_y` setters — position-sensitive touch zones keep working in either orientation.

Testing: rotation logic is hardware-proven on a CoreS3-Lite (in daily use); this packaging compiles clean against `cores3-satellite-base.yaml` with esphome 2026.6.4.

This resubmits the one part of m5stack/M5CoreS3-Esphome#39 not already covered here, per @lboue's pointer to this repo. (The old PRs are closed.)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01TaFALu42vGvofsvrUUyXH9
