### PR TITLE
Fix AtomS3R LCD padding for mipi_spi

### DIFF
--- a/common/atoms3r-with-echo-base.yaml
+++ b/common/atoms3r-with-echo-base.yaml
@@ -562,7 +562,9 @@ display:
       width: 128
       offset_width: 2
       offset_height: 1
-
+      pad_width: 2
+      pad_height: 1
+      
     invert_colors: true
     rotation: 180°
     pages:

--- a/examples/sensor/atomic-audio3.5-base.yaml
+++ b/examples/sensor/atomic-audio3.5-base.yaml
@@ -187,6 +187,8 @@ display:
       width: 128
       offset_width: 2
       offset_height: 1
+      pad_width: 2
+      pad_height: 1
     invert_colors: true
     rotation: 180°
     lambda: |-

--- a/examples/voice_assistant/echo_pyramid_example.yaml
+++ b/examples/voice_assistant/echo_pyramid_example.yaml
@@ -80,7 +80,7 @@ psram:
 
 api:
   encryption:
-    key: !secret api_encryption_key
+    key: "/Ic5szx8+gWlbthXuWg9cTq5RDkih1bl+vfhNfLDW2Q="
 
   on_client_connected:
     - script.execute: draw_display
@@ -89,7 +89,7 @@ api:
 
 ota:
   - platform: esphome
-    password: !secret ota_password
+    password: "6cf9a68db5bb8db6e92a32723ef524cf"
 
 wifi:
   ssid: !secret wifi_ssid
@@ -97,7 +97,7 @@ wifi:
   
   ap:
     ssid: "Echo-Pyramid Fallback Hotspot"
-    password: !secret ap_password
+    password: "uSTvJjVzweZp"
 
   on_connect:
     - script.execute: draw_display
@@ -800,7 +800,7 @@ display:
       offset_height: 1
       pad_width: 2
       pad_height: 1
-      
+
     invert_colors: true
     rotation: 180°
     pages:

--- a/examples/voice_assistant/echo_pyramid_example.yaml
+++ b/examples/voice_assistant/echo_pyramid_example.yaml
@@ -80,7 +80,7 @@ psram:
 
 api:
   encryption:
-    key: "/Ic5szx8+gWlbthXuWg9cTq5RDkih1bl+vfhNfLDW2Q="
+    key: !secret api_encryption_key
 
   on_client_connected:
     - script.execute: draw_display
@@ -89,7 +89,7 @@ api:
 
 ota:
   - platform: esphome
-    password: "6cf9a68db5bb8db6e92a32723ef524cf"
+    password: !secret ota_password
 
 wifi:
   ssid: !secret wifi_ssid
@@ -97,7 +97,7 @@ wifi:
   
   ap:
     ssid: "Echo-Pyramid Fallback Hotspot"
-    password: "uSTvJjVzweZp"
+    password: !secret ap_password
 
   on_connect:
     - script.execute: draw_display
@@ -798,7 +798,9 @@ display:
       width: 128
       offset_width: 2
       offset_height: 1
-
+      pad_width: 2
+      pad_height: 1
+      
     invert_colors: true
     rotation: 180°
     pages:


### PR DESCRIPTION
## Summary

Adds explicit `pad_width` and `pad_height` values to the AtomS3R `atoms3r_lcd` `mipi_spi` display definitions.

ESPHome 2026.6.x changed `mipi_spi` padding/rotation behavior. Without explicit padding, AtomS3R ST7789V displays using `rotation: 180°` can show corrupted/pixelated output even though the device otherwise boots and functions normally.

## Tested

- Confirmed display corruption with ESPHome 2026.6.x
- Confirmed ESPHome 2026.5.3 works without this change
- Confirmed adding `pad_width: 2` and `pad_height: 1` fixes the display while preserving `rotation: 180`

Fixes #96