### PR TITLE
Update the source of the microWakeWord model files

### DIFF
--- a/common/atom-echos3r-satellite-base.yaml
+++ b/common/atom-echos3r-satellite-base.yaml
@@ -9,8 +9,8 @@ substitutions:
   error_cloud_expired_file: https://github.com/esphome/home-assistant-voice-pe/raw/dev/sounds/error_cloud_expired.mp3
 
   # Micro wake word models
-  okay_nabu_model_file: https://github.com/OHF-Voice/microWakeWord/releases/download/okay_nabu_20241226.3/okay_nabu.json
-  stop_model_file: https://github.com/OHF-Voice/microWakeWord/releases/download/stop/stop.json
+  okay_nabu_model_file: https://github.com/OHF-Voice/micro-wake-word/releases/download/okay_nabu_20241226.3/okay_nabu.json
+  stop_model_file: https://github.com/OHF-Voice/micro-wake-word/releases/download/stop/stop.json
 
   # Phases of the Voice Assistant
   # The voice assistant is ready to be triggered by a wake word

--- a/common/atom-echos3r-satellite-base.yaml
+++ b/common/atom-echos3r-satellite-base.yaml
@@ -9,7 +9,7 @@ substitutions:
   error_cloud_expired_file: https://github.com/esphome/home-assistant-voice-pe/raw/dev/sounds/error_cloud_expired.mp3
 
   # Micro wake word models
-  okay_nabu_model_file: https://github.com/kahrendt/microWakeWord/releases/download/okay_nabu_20241226.3/okay_nabu.json
+  okay_nabu_model_file: https://raw.githubusercontent.com/esphome/micro-wake-word-models/348c9aa1328fb2b17ecc59c8bea932cbc09ba1ed/models/v2/hey_jarvis.json
   stop_model_file: https://github.com/kahrendt/microWakeWord/releases/download/stop/stop.json
 
   # Phases of the Voice Assistant

--- a/common/atom-echos3r-satellite-base.yaml
+++ b/common/atom-echos3r-satellite-base.yaml
@@ -9,8 +9,8 @@ substitutions:
   error_cloud_expired_file: https://github.com/esphome/home-assistant-voice-pe/raw/dev/sounds/error_cloud_expired.mp3
 
   # Micro wake word models
-  okay_nabu_model_file: https://raw.githubusercontent.com/esphome/micro-wake-word-models/348c9aa1328fb2b17ecc59c8bea932cbc09ba1ed/models/v2/hey_jarvis.json
-  stop_model_file: https://github.com/kahrendt/microWakeWord/releases/download/stop/stop.json
+  okay_nabu_model_file: https://github.com/OHF-Voice/microWakeWord/releases/download/okay_nabu_20241226.3/okay_nabu.json
+  stop_model_file: https://github.com/OHF-Voice/microWakeWord/releases/download/stop/stop.json
 
   # Phases of the Voice Assistant
   # The voice assistant is ready to be triggered by a wake word


### PR DESCRIPTION
The https://github.com/kahrendt/microWakeWord repository doesn't exist, and it's migrated to the new repo.