### PR TITLE
Fix: move Tab5 display rotation from display config to lvgl config

### DIFF
--- a/common/tab5-ha-hmi.yaml
+++ b/common/tab5-ha-hmi.yaml
@@ -341,7 +341,6 @@ display:
       height: 1280
       width: 720
     model: M5Stack-Tab5
-    rotation: 270°
     reset_pin:
       pi4ioe5v6408: pi4ioe1
       number: 4

--- a/common/tab5-ha-hmi.yaml
+++ b/common/tab5-ha-hmi.yaml
@@ -320,14 +320,18 @@ touchscreen:
     reset_pin:
       pi4ioe5v6408: pi4ioe1
       number: 5
-    transform:
-      swap_xy: true
-      mirror_x: true
+    # No swap_xy/mirror_x here: LVGL now performs the 270° rotation
+    # itself (rotation moved from `display:` to `lvgl:`), and that
+    # rotation already applies to touch input via
+    # LvglComponent::rotate_coordinates(). Applying the same
+    # swap+mirror a second time here double-rotates touches (net
+    # ~180° off). Report native (portrait) panel coordinates instead
+    # and let LVGL do the rotation once.
     calibration:
       x_min: 0
-      x_max: 1280
+      x_max: 720
       y_min: 0
-      y_max: 720
+      y_max: 1280
     id: touch
 
       

--- a/common/tab5-lvgl.yaml
+++ b/common/tab5-lvgl.yaml
@@ -73,6 +73,10 @@ font:
 
 
 lvgl:
+  # Rotation must be set here rather than under `display:` — LVGL owns
+  # the rotation when it manages the display, and recent ESPHome
+  # releases reject `rotation` under the display config in that case.
+  rotation: 270
   on_boot:
     - rx8130.read_time:
     - script.execute: expand_nav_btn_click_area    # Expand the click area of nav rail buttons


### PR DESCRIPTION
## Problem

ESPHome now rejects `rotation` under the `mipi_dsi` display config when LVGL manages the display, failing `esphome config` with:

```
use of 'rotation' in the display config is not compatible with LVGL, please set rotation in the LVGL config instead.
```

https://github.com/m5stack/esphome-yaml/issues/99

This currently breaks `common/tab5-ha-hmi.yaml` on recent ESPHome releases (confirmed against 2026.7.4 and 2026.8.0-dev).

## Fix

Move the existing `rotation: 270°` from `display:` to `lvgl.rotation: 270`.

## Testing

Validated with `esphome config` (both a fresh 2026.7.4 install and a 2026.8.0-dev environment) — config now loads successfully instead of failing.
